### PR TITLE
fix(filename-casing): match against basename rather than full path

### DIFF
--- a/src/rules/filename-casing.test.ts
+++ b/src/rules/filename-casing.test.ts
@@ -20,6 +20,15 @@ describe('filename-casing', () => {
 
       expect(result).toMatchObject({ kind: 'violation' })
     })
+
+    it('allows a kebab-case basename when the path is absolute', () => {
+      const { result } = setup({
+        path: '/Users/foo/Project/src/user-profile.ts',
+        style,
+      })
+
+      expect(result).toEqual({ kind: 'pass' })
+    })
   })
 
   describe('camelCase', () => {

--- a/src/rules/filename-casing.ts
+++ b/src/rules/filename-casing.ts
@@ -1,3 +1,5 @@
+import { basename } from 'node:path'
+
 import type { Rule, RuleResult } from './contract.js'
 import { buildMatcher } from './utils/match-paths.js'
 
@@ -32,7 +34,7 @@ export function filenameCasing(options: {
     if (action.type !== 'write') return pass
     const { path } = action
     if (!matchesPaths(path)) return pass
-    if (violations[style](path)) {
+    if (violations[style](basename(path))) {
       return { kind: 'violation', reason: `${path} does not match ${style}` }
     }
     return pass
@@ -41,17 +43,18 @@ export function filenameCasing(options: {
 
 const pass: RuleResult = { kind: 'pass' }
 
-// kebab-case: no uppercase, no underscores.
-const violatesKebab = (path: string): boolean => /[A-Z_]/.test(path)
-// camelCase: no hyphens; no path segment may start with an uppercase
-// letter. `/\/[A-Z]/` catches `src/UserProfile.ts` (segment-initial cap).
-const violatesCamel = (path: string): boolean =>
-  path.includes('-') || /\/[A-Z]/.test(path)
-// snake_case: no uppercase anywhere.
-const violatesSnake = (path: string): boolean => /[A-Z]/.test(path)
+// kebab-case: no uppercase, no underscores in the filename.
+const violatesKebab = (name: string): boolean => /[A-Z_]/.test(name)
+// camelCase: filename must not start with an uppercase letter and must
+// not contain hyphens. Catches PascalCase (`UserProfile.ts`) and
+// kebab-cased filenames.
+const violatesCamel = (name: string): boolean =>
+  name.includes('-') || /^[A-Z]/.test(name)
+// snake_case: no uppercase anywhere in the filename.
+const violatesSnake = (name: string): boolean => /[A-Z]/.test(name)
 
 const violations = {
   'kebab-case': violatesKebab,
   camelCase: violatesCamel,
   snake_case: violatesSnake,
-} satisfies Record<Style, (path: string) => boolean>
+} satisfies Record<Style, (name: string) => boolean>


### PR DESCRIPTION
Closes #2.

filenameCasing tests the whole action.path string with regex, so any write whose path passes through an uppercase ancestor segment was wrongly flagged. Since Claude Code sends file_path as an absolute path, the rule rejected essentially every write in real sessions.

This change switches the casing predicates to operate on `path.basename(action.path)` so only the filename is evaluated. A regression test under kebab-case is added.

Test plan:
- `npm test`: 177 passed (one new), 15 skipped, no regressions.
- Manual probe via `node dist/bin.js` with `test/fixtures/configs/kebab-only.config.ts` and an absolute `file_path` now returns allow. PascalCase basenames such as `src/FooBar.ts` are still correctly denied. camelCase and snake_case were verified the same way.