### PR TITLE
fix: relativize Action.path against payload cwd

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,10 @@
  * Canonical action an agent attempts, as seen by rules and the engine.
  * Adapters translate vendor-specific hook payloads into this shape.
  *
- * - `write` — a file write or edit; carries the target path and the
- *   content being written.
+ * - `write` — a file write or edit. `path` is project-relative POSIX
+ *   (adapters normalize it against the payload `cwd`), so rule globs
+ *   can be authored as `'src/**'`. Rules that read the file from disk
+ *   should resolve against `process.cwd()`.
  * - `command` — a shell command invocation; carries the command text.
  */
 export type Action =

--- a/src/vendors/claude-code/adapter.test.ts
+++ b/src/vendors/claude-code/adapter.test.ts
@@ -5,10 +5,10 @@ import { describe, it, expect } from 'vitest'
 import { actionSchema, sessionPath, toResponse } from './adapter.js'
 
 describe('claude-code adapter', () => {
-  it('extracts the file path from a Write payload', () => {
-    const { action, payload } = setup('write-new-file.json')
+  it('extracts the file path from a Write payload, relative to cwd', () => {
+    const { action } = setup('write-new-file.json')
 
-    expect(action).toMatchObject({ path: payload.tool_input.file_path })
+    expect(action).toMatchObject({ path: 'src/userProfile.ts' })
   })
 
   it('tags the action type as write for a Write payload', () => {
@@ -41,10 +41,45 @@ describe('claude-code adapter', () => {
     expect(action).toMatchObject({ content: payload.tool_input.new_string })
   })
 
-  it('extracts the file path from an Edit payload', () => {
-    const { action, payload } = setup('edit-file.json')
+  it('extracts the file path from an Edit payload, relative to cwd', () => {
+    const { action } = setup('edit-file.json')
 
-    expect(action).toMatchObject({ path: payload.tool_input.file_path })
+    expect(action).toMatchObject({ path: 'README.md' })
+  })
+
+  it('relativizes an absolute file_path against the payload cwd', () => {
+    const action = actionSchema.parse({
+      cwd: '/workspaces/conduct',
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '/workspaces/conduct/src/UpperCase.ts',
+        content: 'x',
+      },
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
+  })
+
+  it('falls back to process.cwd() when the payload omits cwd', () => {
+    const action = actionSchema.parse({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: `${process.cwd()}/src/UpperCase.ts`,
+        content: 'x',
+      },
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
+  })
+
+  it('returns ../-prefixed form for an absolute file_path that sits outside cwd', () => {
+    const action = actionSchema.parse({
+      cwd: '/workspaces/conduct',
+      tool_name: 'Write',
+      tool_input: { file_path: '/etc/passwd', content: 'x' },
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: '../../etc/passwd' })
   })
 
   it('returns no opinion (empty stdout) on an allow decision so normal permission flow takes over', () => {

--- a/src/vendors/claude-code/adapter.ts
+++ b/src/vendors/claude-code/adapter.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import type { Action, Decision } from '../../types.js'
+import { relativizePath } from '../relativize-path.js'
 
 const KNOWN_TOOL_NAMES = new Set(['Bash', 'Edit', 'Write'])
 
@@ -20,11 +21,12 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
         file_path: z.string(),
         new_string: z.string(),
       }),
+      cwd: z.string().optional(),
     })
     .transform(
       (d): Action => ({
         type: 'write',
-        path: d.tool_input.file_path,
+        path: relativizePath(d.cwd, d.tool_input.file_path),
         content: d.tool_input.new_string,
       }),
     ),
@@ -35,11 +37,12 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
         file_path: z.string(),
         content: z.string(),
       }),
+      cwd: z.string().optional(),
     })
     .transform(
       (d): Action => ({
         type: 'write',
-        path: d.tool_input.file_path,
+        path: relativizePath(d.cwd, d.tool_input.file_path),
         content: d.tool_input.content,
       }),
     ),

--- a/src/vendors/codex/adapter.test.ts
+++ b/src/vendors/codex/adapter.test.ts
@@ -50,7 +50,7 @@ describe('codex adapter', () => {
     ).toThrow()
   })
 
-  it('maps an apply_patch payload to a write action with path + patch content', () => {
+  it('maps an apply_patch payload to a write action with path (relative to cwd) + patch content', () => {
     const payload = JSON.parse(
       readFileSync('test/fixtures/codex/pre-apply-patch.json', 'utf8'),
     )
@@ -59,9 +59,33 @@ describe('codex adapter', () => {
 
     expect(action.type).toBe('write')
     if (action.type !== 'write') throw new Error('expected write')
-    expect(action.path).toBe('/workspaces/conduct/src/calculator.ts')
+    expect(action.path).toBe('src/calculator.ts')
     expect(action.content).toContain('*** Begin Patch')
     expect(action.content).toContain('*** Add File:')
+  })
+
+  it('relativizes an absolute apply_patch header path against the payload cwd', () => {
+    const action = actionSchema.parse({
+      cwd: '/workspaces/conduct',
+      tool_name: 'apply_patch',
+      tool_input: {
+        command:
+          '*** Begin Patch\n*** Add File: /workspaces/conduct/src/UpperCase.ts\n+x\n*** End Patch\n',
+      },
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
+  })
+
+  it('falls back to process.cwd() when the apply_patch payload omits cwd', () => {
+    const action = actionSchema.parse({
+      tool_name: 'apply_patch',
+      tool_input: {
+        command: `*** Begin Patch\n*** Add File: ${process.cwd()}/src/UpperCase.ts\n+x\n*** End Patch\n`,
+      },
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
   })
 
   it('passes through an unsupported tool_name as a no-op so unknown tools are not blocked', () => {

--- a/src/vendors/codex/adapter.ts
+++ b/src/vendors/codex/adapter.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import type { Action, Decision } from '../../types.js'
+import { relativizePath } from '../relativize-path.js'
 
 const PATCH_HEADER = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/m
 
@@ -19,6 +20,7 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
     .object({
       tool_name: z.literal('apply_patch'),
       tool_input: z.object({ command: z.string() }),
+      cwd: z.string().optional(),
     })
     .transform((d, ctx): Action => {
       const path = PATCH_HEADER.exec(d.tool_input.command)?.[1]
@@ -29,7 +31,11 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
         })
         return z.NEVER
       }
-      return { type: 'write', path, content: d.tool_input.command }
+      return {
+        type: 'write',
+        path: relativizePath(d.cwd, path),
+        content: d.tool_input.command,
+      }
     }),
 ])
 

--- a/src/vendors/github-copilot-chat/adapter.test.ts
+++ b/src/vendors/github-copilot-chat/adapter.test.ts
@@ -51,11 +51,11 @@ describe('github-copilot-chat adapter', () => {
     expect(action.type).toBe('write')
   })
 
-  it('maps create_file payload filePath + content onto the write action', () => {
+  it('maps create_file payload filePath (relative to cwd) + content onto the write action', () => {
     const { action, payload } = setup('pre-create-file.json')
 
     expect(action).toMatchObject({
-      path: payload.tool_input.filePath,
+      path: 'src/shopping-cart.test.ts',
       content: payload.tool_input.content,
     })
   })
@@ -66,13 +66,38 @@ describe('github-copilot-chat adapter', () => {
     expect(action.type).toBe('write')
   })
 
-  it('maps replace_string_in_file payload filePath + newString onto the write action', () => {
+  it('maps replace_string_in_file payload filePath (relative to cwd) + newString onto the write action', () => {
     const { action, payload } = setup('pre-replace-string-in-file.json')
 
     expect(action).toMatchObject({
-      path: payload.tool_input.filePath,
+      path: 'src/shopping-cart.test.ts',
       content: payload.tool_input.newString,
     })
+  })
+
+  it('relativizes an absolute create_file filePath against the payload cwd', () => {
+    const action = actionSchema.parse({
+      cwd: '/workspaces/conduct',
+      tool_name: 'create_file',
+      tool_input: {
+        filePath: '/workspaces/conduct/src/UpperCase.ts',
+        content: 'x',
+      },
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
+  })
+
+  it('falls back to process.cwd() when the create_file payload omits cwd', () => {
+    const action = actionSchema.parse({
+      tool_name: 'create_file',
+      tool_input: {
+        filePath: `${process.cwd()}/src/UpperCase.ts`,
+        content: 'x',
+      },
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
   })
 
   it('passes through read_file as a no-op so reads are not blocked by an unknown-tool error', () => {

--- a/src/vendors/github-copilot-chat/adapter.ts
+++ b/src/vendors/github-copilot-chat/adapter.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import type { Action, Decision } from '../../types.js'
+import { relativizePath } from '../relativize-path.js'
 
 export function toResponse(decision: Decision): string {
   if (decision.kind === 'block') {
@@ -28,11 +29,12 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
     .object({
       tool_name: z.literal('create_file'),
       tool_input: z.object({ filePath: z.string(), content: z.string() }),
+      cwd: z.string().optional(),
     })
     .transform(
       (d): Action => ({
         type: 'write',
-        path: d.tool_input.filePath,
+        path: relativizePath(d.cwd, d.tool_input.filePath),
         content: d.tool_input.content,
       }),
     ),
@@ -40,11 +42,12 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
     .object({
       tool_name: z.literal('replace_string_in_file'),
       tool_input: z.object({ filePath: z.string(), newString: z.string() }),
+      cwd: z.string().optional(),
     })
     .transform(
       (d): Action => ({
         type: 'write',
-        path: d.tool_input.filePath,
+        path: relativizePath(d.cwd, d.tool_input.filePath),
         content: d.tool_input.newString,
       }),
     ),

--- a/src/vendors/github-copilot/adapter.test.ts
+++ b/src/vendors/github-copilot/adapter.test.ts
@@ -45,24 +45,55 @@ describe('github-copilot adapter', () => {
     expect(action.type).toBe('write')
   })
 
-  it('maps create payload path + file_text onto the write action', () => {
+  it('maps create payload path (relative to cwd) + file_text onto the write action', () => {
     const { action, payload } = setup('pre-create-new-test.json')
     const args = JSON.parse(payload.toolArgs) as {
       path: string
       file_text: string
     }
 
-    expect(action).toMatchObject({ path: args.path, content: args.file_text })
+    expect(action).toMatchObject({
+      path: 'test/calculator.test.ts',
+      content: args.file_text,
+    })
   })
 
-  it('maps an edit payload path + new_str onto the write action', () => {
+  it('maps an edit payload path (relative to cwd) + new_str onto the write action', () => {
     const { action, payload } = setup('pre-edit-add-subtract.json')
     const args = JSON.parse(payload.toolArgs) as {
       path: string
       new_str: string
     }
 
-    expect(action).toMatchObject({ path: args.path, content: args.new_str })
+    expect(action).toMatchObject({
+      path: 'test/calculator.test.ts',
+      content: args.new_str,
+    })
+  })
+
+  it('relativizes an absolute create path against the payload cwd', () => {
+    const action = actionSchema.parse({
+      cwd: '/workspaces/conduct',
+      toolName: 'create',
+      toolArgs: JSON.stringify({
+        path: '/workspaces/conduct/src/UpperCase.ts',
+        file_text: 'x',
+      }),
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
+  })
+
+  it('falls back to process.cwd() when the create payload omits cwd', () => {
+    const action = actionSchema.parse({
+      toolName: 'create',
+      toolArgs: JSON.stringify({
+        path: `${process.cwd()}/src/UpperCase.ts`,
+        file_text: 'x',
+      }),
+    })
+
+    expect(action).toMatchObject({ type: 'write', path: 'src/UpperCase.ts' })
   })
 
   it('passes through view as a no-op so reads are not blocked by an unknown-tool error', () => {

--- a/src/vendors/github-copilot/adapter.ts
+++ b/src/vendors/github-copilot/adapter.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 
 import type { Action, Decision } from '../../types.js'
 import { JsonString } from '../../utils/json-string.js'
+import { relativizePath } from '../relativize-path.js'
 
 const KNOWN_TOOL_NAMES = new Set(['bash', 'create', 'edit'])
 
@@ -23,11 +24,12 @@ const writeToolsSchema = z.discriminatedUnion('toolName', [
       toolArgs: JsonString.pipe(
         z.object({ path: z.string(), file_text: z.string() }),
       ),
+      cwd: z.string().optional(),
     })
     .transform(
       (d): Action => ({
         type: 'write',
-        path: d.toolArgs.path,
+        path: relativizePath(d.cwd, d.toolArgs.path),
         content: d.toolArgs.file_text,
       }),
     ),
@@ -37,11 +39,12 @@ const writeToolsSchema = z.discriminatedUnion('toolName', [
       toolArgs: JsonString.pipe(
         z.object({ path: z.string(), new_str: z.string() }),
       ),
+      cwd: z.string().optional(),
     })
     .transform(
       (d): Action => ({
         type: 'write',
-        path: d.toolArgs.path,
+        path: relativizePath(d.cwd, d.toolArgs.path),
         content: d.toolArgs.new_str,
       }),
     ),

--- a/src/vendors/relativize-path.test.ts
+++ b/src/vendors/relativize-path.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+
+import { relativizePath } from './relativize-path.js'
+
+describe('relativizePath', () => {
+  it('relativizes an absolute path under cwd', () => {
+    expect(
+      relativizePath('/workspaces/conduct', '/workspaces/conduct/src/foo.ts'),
+    ).toBe('src/foo.ts')
+  })
+
+  it('leaves a path that is already relative to cwd unchanged', () => {
+    expect(relativizePath('/workspaces/conduct', 'src/foo.ts')).toBe(
+      'src/foo.ts',
+    )
+  })
+
+  it('returns ../-prefixed form for an absolute path that sits outside cwd', () => {
+    expect(relativizePath('/workspaces/conduct', '/etc/passwd')).toBe(
+      '../../etc/passwd',
+    )
+  })
+
+  it('returns "." when path equals cwd', () => {
+    expect(relativizePath('/workspaces/conduct', '/workspaces/conduct')).toBe(
+      '.',
+    )
+  })
+
+  it('falls back to process.cwd() when cwd is undefined', () => {
+    const here = process.cwd()
+    expect(relativizePath(undefined, `${here}/foo/bar.ts`)).toBe('foo/bar.ts')
+  })
+
+  it('falls back to process.cwd() when cwd is an empty string', () => {
+    const here = process.cwd()
+    expect(relativizePath('', `${here}/foo/bar.ts`)).toBe('foo/bar.ts')
+  })
+})

--- a/src/vendors/relativize-path.test.ts
+++ b/src/vendors/relativize-path.test.ts
@@ -32,6 +32,16 @@ describe('relativizePath', () => {
     expect(relativizePath(undefined, `${here}/foo/bar.ts`)).toBe('foo/bar.ts')
   })
 
+  it('returns POSIX-style separators even on hosts where path.sep is "\\"', () => {
+    const result = relativizePath(
+      '/workspaces/conduct',
+      '/workspaces/conduct/src/sub/foo.ts',
+    )
+
+    expect(result).not.toContain('\\')
+    expect(result).toBe('src/sub/foo.ts')
+  })
+
   it('falls back to process.cwd() when cwd is an empty string', () => {
     const here = process.cwd()
     expect(relativizePath('', `${here}/foo/bar.ts`)).toBe('foo/bar.ts')

--- a/src/vendors/relativize-path.ts
+++ b/src/vendors/relativize-path.ts
@@ -1,0 +1,15 @@
+import path from 'node:path'
+
+/**
+ * Project-relative form of `p`, anchored at `cwd` (or `process.cwd()`
+ * when cwd is missing, matching the config loader). Lets rule path
+ * matchers (`files`, `paths`) be written as `'src/**'` regardless of
+ * how the agent reports the path.
+ *
+ * Paths that resolve outside cwd come back as `../...`, so a `'src/**'`
+ * matcher naturally won't match them.
+ */
+export function relativizePath(cwd: string | undefined, p: string): string {
+  const base = cwd && cwd.length > 0 ? cwd : process.cwd()
+  return path.relative(base, path.resolve(base, p)) || '.'
+}

--- a/src/vendors/relativize-path.ts
+++ b/src/vendors/relativize-path.ts
@@ -1,15 +1,17 @@
 import path from 'node:path'
 
 /**
- * Project-relative form of `p`, anchored at `cwd` (or `process.cwd()`
- * when cwd is missing, matching the config loader). Lets rule path
- * matchers (`files`, `paths`) be written as `'src/**'` regardless of
- * how the agent reports the path.
+ * Project-relative POSIX form of `p`, anchored at `cwd` (or
+ * `process.cwd()` when cwd is missing, matching the config loader).
+ * Lets rule path matchers (`files`, `paths`) be written as `'src/**'`
+ * regardless of how the agent reports the path or which OS Node runs
+ * on.
  *
- * Paths that resolve outside cwd come back as `../...`, so a `'src/**'`
- * matcher naturally won't match them.
+ * Paths that resolve outside cwd come back as `../...`. Output always
+ * uses `/` separators because picomatch is POSIX-only.
  */
 export function relativizePath(cwd: string | undefined, p: string): string {
   const base = cwd && cwd.length > 0 ? cwd : process.cwd()
-  return path.relative(base, path.resolve(base, p)) || '.'
+  const rel = path.relative(base, path.resolve(base, p)) || '.'
+  return rel.split(path.sep).join('/')
 }

--- a/test/fixtures/configs/relative-glob.config.ts
+++ b/test/fixtures/configs/relative-glob.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, forbidContentPattern } from '../../../src/index.js'
+
+// Uses non-anchored relative globs (no `**/` prefix) to exercise the
+// adapter-side cwd relativization. Pre-fix this would silently no-op
+// against absolute paths in vendor payloads. The rule itself fires on
+// any non-empty content, so a deny is the unambiguous "the matcher
+// engaged" signal.
+export default defineConfig({
+  rules: [
+    {
+      files: ['src/**', 'test/**'],
+      rules: [
+        forbidContentPattern({
+          match: /./,
+          reason: 'relative-glob matcher engaged',
+        }),
+      ],
+    },
+  ],
+})

--- a/test/integration/cli.e2e.test.ts
+++ b/test/integration/cli.e2e.test.ts
@@ -102,6 +102,61 @@ describe('conduct cli (integration)', () => {
     expect(stdout).toBe('')
   })
 
+  // Vendor payloads carry absolute paths; each adapter must relativize
+  // against the payload cwd before the matcher so non-anchored globs
+  // like `files: ['src/**']` reach the rule.
+  it.each([
+    {
+      vendor: 'claude-code',
+      fixture: 'test/fixtures/claude-code/write-new-file.json',
+      readDeny: (out: string) =>
+        JSON.parse(out).hookSpecificOutput.permissionDecision,
+      expected: 'deny',
+    },
+    {
+      vendor: 'codex',
+      fixture: 'test/fixtures/codex/pre-apply-patch.json',
+      readDeny: (out: string) => JSON.parse(out).decision,
+      expected: 'block',
+    },
+    {
+      vendor: 'github-copilot',
+      fixture: 'test/fixtures/github-copilot/pre-create-new-test.json',
+      readDeny: (out: string) => JSON.parse(out).permissionDecision,
+      expected: 'deny',
+    },
+    {
+      vendor: 'github-copilot-chat',
+      fixture: 'test/fixtures/github-copilot-chat/pre-create-file.json',
+      readDeny: (out: string) =>
+        JSON.parse(out).hookSpecificOutput.permissionDecision,
+      expected: 'deny',
+    },
+  ])(
+    'relativizes absolute paths so files: ["src/**"] reaches the rule on $vendor',
+    async ({ vendor, fixture, readDeny, expected }) => {
+      const payload = readFileSync(fixture, 'utf8')
+
+      const { stdout, stderr } = await runCliAt(
+        'dist/bin.js',
+        [
+          '--agent',
+          vendor,
+          '--config',
+          'test/fixtures/configs/relative-glob.config.ts',
+        ],
+        payload,
+      )
+      if (!stdout) {
+        throw new Error(
+          `expected ${vendor} matcher to engage and produce a deny; stdout was empty. stderr: ${stderr}`,
+        )
+      }
+
+      expect(readDeny(stdout)).toBe(expected)
+    },
+  )
+
   it('runs main() when invoked via a symlink (the npx case)', async () => {
     const dir = await new Promise<string>((resolve, reject) => {
       mkdtemp(path.join(tmpdir(), 'conduct-bin-link-'), (err, d) =>


### PR DESCRIPTION
Fixes #4. Adapter-side relativization per the direction in the issue thread.

## Summary

Each vendor adapter now reads the payload `cwd` and normalizes the agent-supplied
file path to a project-relative POSIX form before constructing the `Action`. The
engine and rule path matchers stay vendor-neutral and just consume `Action.path`.

The `Action.path` contract is now: project-relative, POSIX separators. Documented
on the type so rules that need the on-disk path know to resolve against
`process.cwd()` (which equals the payload cwd in CLI mode, so `enforce-tdd`'s
`readBeforeContent` keeps working without change).

## Scope

Verified on v0.0.13 that the bug is wider than the original report:

- All four adapters: claude-code, codex, github-copilot, github-copilot-chat
- Block-level `files` and rule-level `paths` (used by `enforceFilenameCasing`,
  `enforceTdd`, `forbidContentPattern`)
- Negation `'!src/**'` was symmetrically broken; the same fix covers it

## Edge cases

- `cwd` missing from the payload — fall back to `process.cwd()`, matching
  `cli.ts`'s config discovery
- Path resolves outside the project — relative form comes back as `../...`,
  so a `'src/**'` matcher naturally won't match
- Windows separators — normalized to `/` in the helper, because picomatch is
  POSIX-only and Node's `fs` accepts `/` on Windows too

## Out of scope

- Codex `apply_patch` only extracts the first `*** Add/Update/Delete File:`
  header. Multi-file patches are a pre-existing limitation; happy to open a
  separate issue if useful.
- Doc examples in `README.md` and `docs/rules.md` already work post-fix
  (`'src/**'` matches as written), so no change here. Happy to follow up to
  align them with the dogfood `'**/src/**'` style if you'd prefer.

## Tests

`npm run checks` clean. New coverage:

- Helper unit tests (cwd present/absent, outside-project, separator normalization)
- Per-adapter unit tests for the relativization (absolute -> relative,
  cwd-absent fallback)
- E2E in `test/integration/cli.e2e.test.ts` runs each vendor's real fixture
  (which carries an absolute path) through the bin against a config that uses
  `files: ['src/**', 'test/**']` (no `**/` workaround) and asserts the deny
  reaches the rule across all four vendors