### PR TITLE
refactor(rules): move trim-history next to its only consumer

### DIFF
--- a/src/rules/enforce-tdd.ts
+++ b/src/rules/enforce-tdd.ts
@@ -5,7 +5,7 @@ import type { Action, RawSessionEvent } from '../types.js'
 import type { RuleContext, RuleResult } from './contract.js'
 import { countNewTestNodes } from './matchers/count-new-test-nodes.js'
 import { inferLanguage } from './matchers/languages/index.js'
-import { trimHistory, type HistoryWindow } from './utils/trim-history.js'
+import { trimHistory, type HistoryWindow } from './trim-history.js'
 
 const DEFAULT_MAX_EVENTS = 20
 const DEFAULT_MAX_CONTENT_CHARS = 4000

--- a/src/rules/trim-history.test.ts
+++ b/src/rules/trim-history.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import type { RawSessionEvent } from '../../types.js'
+import type { RawSessionEvent } from '../types.js'
 import { trimHistory } from './trim-history.js'
 
 describe('trimHistory', () => {

--- a/src/rules/trim-history.ts
+++ b/src/rules/trim-history.ts
@@ -1,4 +1,4 @@
-import type { RawSessionEvent } from '../../types.js'
+import type { RawSessionEvent } from '../types.js'
 
 export type HistoryWindow = {
   maxEvents: number


### PR DESCRIPTION
## Problem

\`trim-history.ts\` lives in \`src/rules/utils/\`, which signals "shared helper anyone can grab." In practice it has one consumer (\`enforce-tdd.ts\`), owns a rule-specific type (\`HistoryWindow\`), and exists solely to feed \`buildPrompt\`. The two files that genuinely belong in \`utils/\` are \`match-paths\` and \`string-or-regex-matches\` — both used by multiple rules.

## Changes

Moves the file and its test next to their consumer:

```
src/rules/utils/trim-history.ts        → src/rules/trim-history.ts
src/rules/utils/trim-history.test.ts   → src/rules/trim-history.test.ts
```

Import path in both files: \`../../types.js\` → \`../types.js\`

Import in \`enforce-tdd.ts\`:
```ts
- import { trimHistory, type HistoryWindow } from './utils/trim-history.js'
+ import { trimHistory, type HistoryWindow } from './trim-history.js'
```

\`rules/utils/\` now contains only \`match-paths\` and \`string-or-regex-matches\`.

## Tests

- [x] \`npm run build\` — clean
- [x] \`npm run checks\` — ESLint, Prettier, TypeScript all pass
- [x] \`npx vitest run\` — 329 tests pass, 15 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)