### PR TITLE
docs: Fix command key in setup.md for hooks

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -91,7 +91,7 @@ The Copilot Chat extension (VS Code) reads hooks from `.github/hooks/probity.jso
     "preToolUse": [
       {
         "type": "command",
-        "bash": "npx @nizos/probity --agent github-copilot-chat"
+        "command": "npx @nizos/probity --agent github-copilot-chat"
       }
     ]
   }
@@ -111,7 +111,7 @@ GitHub Copilot CLI reads hooks from the same `.github/hooks/probity.json` — th
     "preToolUse": [
       {
         "type": "command",
-        "bash": "npx @nizos/probity --agent github-copilot"
+        "command": "npx @nizos/probity --agent github-copilot"
       }
     ]
   }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -91,14 +91,16 @@ The Copilot Chat extension (VS Code) reads hooks from `.github/hooks/probity.jso
     "preToolUse": [
       {
         "type": "command",
-        "command": "npx @nizos/probity --agent github-copilot-chat"
+        "bash": "npx @nizos/probity --agent github-copilot-chat",
+        "powershell": "npx @nizos/probity --agent github-copilot-chat"
       }
     ]
   }
 }
 ```
+Note the use of `bash` and `powershell` in this example, select the shell option available for your environment.
 
-Every tool call fires the hook; probity's rules pass through non-write actions. The Chat adapter accepts `run_in_terminal`, `create_file`, and `replace_string_in_file` payloads.
+Every tool call fires the hook; probity's rules pass through non-write actions. The Chat adapter accepts `run_in_terminal`, `create_file`, and `replace_string_in_file` payloads. 
 
 ## GitHub Copilot CLI
 
@@ -111,12 +113,14 @@ GitHub Copilot CLI reads hooks from the same `.github/hooks/probity.json` — th
     "preToolUse": [
       {
         "type": "command",
-        "command": "npx @nizos/probity --agent github-copilot"
+        "bash": "npx @nizos/probity --agent github-copilot",
+        "powershell": "npx @nizos/probity --agent github-copilot"
       }
     ]
   }
 }
 ```
+Note the use of `bash` and `powershell` in this example, select the shell option available for your environment.
 
 Every tool call fires the hook; probity's rules pass through non-write actions. Probity accepts Copilot's `bash`, `create`, and `edit` tool payloads.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -98,9 +98,10 @@ The Copilot Chat extension (VS Code) reads hooks from `.github/hooks/probity.jso
   }
 }
 ```
+
 Note the use of `bash` and `powershell` in this example, select the shell option available for your environment.
 
-Every tool call fires the hook; probity's rules pass through non-write actions. The Chat adapter accepts `run_in_terminal`, `create_file`, and `replace_string_in_file` payloads. 
+Every tool call fires the hook; probity's rules pass through non-write actions. The Chat adapter accepts `run_in_terminal`, `create_file`, and `replace_string_in_file` payloads.
 
 ## GitHub Copilot CLI
 
@@ -120,6 +121,7 @@ GitHub Copilot CLI reads hooks from the same `.github/hooks/probity.json` — th
   }
 }
 ```
+
 Note the use of `bash` and `powershell` in this example, select the shell option available for your environment.
 
 Every tool call fires the hook; probity's rules pass through non-write actions. Probity accepts Copilot's `bash`, `create`, and `edit` tool payloads.


### PR DESCRIPTION
This pull request updates the documentation to clarify the correct key to use for command hooks in the `.github/hooks/probity.json` configuration. Specifically, it replaces the deprecated `bash` key with the correct `command` key in two code examples.

Documentation updates:

* Updated code examples in `docs/setup.md` to use the `powershell` key and `bash` for specifying commands in the `preToolUse` hook configuration. [[1]](diffhunk://#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23L94-R94) [[2]](diffhunk://#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23L114-R114)