### PR TITLE
fix(matchers): cover xit/fit/.todo and full chains in TS/JS test-node matcher

### DIFF
--- a/src/rules/matchers/count-new-test-nodes.test.ts
+++ b/src/rules/matchers/count-new-test-nodes.test.ts
@@ -94,6 +94,83 @@ describe.each([
 
     expect(countNewTestNodes(before, after, language)).toBe(1)
   })
+
+  it('counts it.todo() as a test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { it.todo('a') })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('counts test.todo() as a test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { test.todo('a') })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('counts xit() as a test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { xit('a', () => {}) })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('counts fit() as a test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { fit('a', () => {}) })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('counts xtest() as a test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { xtest('a', () => {}) })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('counts ftest() as a test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { ftest('a', () => {}) })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('counts it.failing() as a test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { it.failing('a', () => {}) })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('counts a deep chain like it.concurrent.skip.each() as a single test node', () => {
+    const before = `describe('x', () => {})`
+    const after = `describe('x', () => { it.concurrent.skip.each([1])('case %i', (n) => {}) })`
+
+    expect(countNewTestNodes(before, after, language)).toBe(1)
+  })
+
+  it('does not count `it` from a named import as a test node', () => {
+    const before = ``
+    const after = `import { it } from 'vitest'`
+
+    expect(countNewTestNodes(before, after, language)).toBe(0)
+  })
+
+  it('does not count a local `it` binding as a test node', () => {
+    const before = ``
+    const after = `const it = (name, fn) => fn()`
+
+    expect(countNewTestNodes(before, after, language)).toBe(0)
+  })
+
+  it('does not count obj.it() where `it` is a property name', () => {
+    const before = ``
+    const after = `obj.it()`
+
+    expect(countNewTestNodes(before, after, language)).toBe(0)
+  })
 })
 
 describe('countNewTestNodes (python)', () => {

--- a/src/rules/matchers/languages/javascript.ts
+++ b/src/rules/matchers/languages/javascript.ts
@@ -1,17 +1,34 @@
 import { Lang } from '@ast-grep/napi'
 
+const TEST_NAME_REGEX = '^(it|test|xit|fit|xtest|ftest)$'
+
+const ID_RULE = { kind: 'identifier', regex: TEST_NAME_REGEX }
+const M1 = {
+  kind: 'member_expression',
+  has: { field: 'object', ...ID_RULE },
+}
+const M2 = {
+  kind: 'member_expression',
+  has: { field: 'object', any: [ID_RULE, M1] },
+}
+const M3 = {
+  kind: 'member_expression',
+  has: { field: 'object', any: [ID_RULE, M1, M2] },
+}
+
 export const javascript = {
   name: 'javascript',
   extensions: ['.js'],
   parser: Lang.JavaScript,
   patterns: [
-    'it($$$ARGS)',
-    'test($$$ARGS)',
-    'it.skip($$$ARGS)',
-    'it.only($$$ARGS)',
-    'test.skip($$$ARGS)',
-    'test.only($$$ARGS)',
-    'test.each($$$ARGS)',
-    'it.each($$$ARGS)',
+    {
+      rule: {
+        kind: 'call_expression',
+        has: {
+          field: 'function',
+          any: [ID_RULE, M1, M2, M3],
+        },
+      },
+    },
   ],
-} as const
+}

--- a/src/rules/matchers/languages/typescript.ts
+++ b/src/rules/matchers/languages/typescript.ts
@@ -1,17 +1,34 @@
 import { Lang } from '@ast-grep/napi'
 
+const TEST_NAME_REGEX = '^(it|test|xit|fit|xtest|ftest)$'
+
+const ID_RULE = { kind: 'identifier', regex: TEST_NAME_REGEX }
+const M1 = {
+  kind: 'member_expression',
+  has: { field: 'object', ...ID_RULE },
+}
+const M2 = {
+  kind: 'member_expression',
+  has: { field: 'object', any: [ID_RULE, M1] },
+}
+const M3 = {
+  kind: 'member_expression',
+  has: { field: 'object', any: [ID_RULE, M1, M2] },
+}
+
 export const typescript = {
   name: 'typescript',
   extensions: ['.ts', '.tsx'],
   parser: Lang.TypeScript,
   patterns: [
-    'it($$$ARGS)',
-    'test($$$ARGS)',
-    'it.skip($$$ARGS)',
-    'it.only($$$ARGS)',
-    'test.skip($$$ARGS)',
-    'test.only($$$ARGS)',
-    'test.each($$$ARGS)',
-    'it.each($$$ARGS)',
+    {
+      rule: {
+        kind: 'call_expression',
+        has: {
+          field: 'function',
+          any: [ID_RULE, M1, M2, M3],
+        },
+      },
+    },
   ],
-} as const
+}


### PR DESCRIPTION
## Summary

Closes #13.

The TS/JS fast-path test-node matcher enumerated 8 literal ast-grep patterns (`it`, `test`, `.skip`, `.only`, `.each`), so `xit`, `fit`, `xtest`, `ftest`, `it.todo`, `test.todo`, `it.failing`, `it.concurrent`, and deeper chains like `it.concurrent.skip.each(...)` were silently counted as zero. The user-visible effect was `enforceTdd` blocking impl edits when the new test was written with any of those forms.

This PR switches TS/JS to the rule-object form already used by Ruby, addressing the two points from the issue thread:

- **Function-position scoping.** The match is anchored at `kind: call_expression` and walks `has: { field: 'function', ... }`, so the test-name regex only fires on identifiers at the call's callee position or as the leftmost identifier of a `member_expression` chain. The `kind: identifier` constraint excludes `property_identifier`, which means `import { it }` (named-import specifier), `const it = ...` (variable declarator), `obj.it()` (`it` as a property), and `someFn(it)` (`it` as an argument) all stop counting structurally rather than by accident.
- **Full structural vocabulary.** The regex is `^(it|test|xit|fit|xtest|ftest)$`, and the property side of every member chain is unconstrained, so `.todo`, `.failing`, `.concurrent`, `.skip`, `.only`, `.each` and any future modifier all count automatically. Member chains are matched up to depth 3 via nested `any` rules, which covers every real Vitest/Jest form including `it.concurrent.skip.each([...])('case %i', ...)`.

## Test plan

- [x] `npm run checks` (lint + format + typecheck + 385-test vitest suite) passes locally.
- [x] Added positive parameterised cases for `it.todo`, `test.todo`, `xit`, `fit`, `xtest`, `ftest`, `it.failing`, and the depth-3 chain `it.concurrent.skip.each(...)`.
- [x] Added negative regression guards for the false-positive shapes called out in the issue thread: `import { it } from 'vitest'`, `const it = (name, fn) => fn()`, and `obj.it()`.
- [x] All previously-green tests (`it`/`test`/`.skip`/`.only`/`.each`, plus the parameterised `test.each([...])('case %i', ...)`) still pass — the rule produces exactly one match per test node call.

## Notes

- I considered going wider than depth 3, but I could not find a real Vitest/Jest form that exceeds it. Happy to extend or generalise if you have a case in mind.
- The two language files end up with the same helper definitions. I left them duplicated to keep this PR scoped to the bug fix; happy to extract a shared helper in a follow-up if you'd prefer.