### PR TITLE
fix(copilot): classify edit-style actions as writes in canonical history

### DIFF
--- a/src/vendors/github-copilot-chat/event.test.ts
+++ b/src/vendors/github-copilot-chat/event.test.ts
@@ -42,6 +42,27 @@ describe('toCanonical (github-copilot-chat)', () => {
     })
   })
 
+  it('classifies a replace_string_in_file action as a write event using newString as content', () => {
+    const result = toCanonical({
+      kind: 'action',
+      tool: 'replace_string_in_file',
+      input: {
+        filePath: '/abs/src/calc.ts',
+        oldString: 'old',
+        newString: 'new',
+      },
+      output: 'edited',
+      toolUseId: 'call_edit',
+    })
+
+    expect(result).toEqual({
+      kind: 'write',
+      path: '/abs/src/calc.ts',
+      content: 'new',
+      output: 'edited',
+    })
+  })
+
   it('classifies an unrecognized tool as an other event, preserving raw input', () => {
     const result = toCanonical({
       kind: 'action',

--- a/src/vendors/github-copilot-chat/event.ts
+++ b/src/vendors/github-copilot-chat/event.ts
@@ -14,6 +14,18 @@ export function toCanonical(event: RawSessionEvent): SessionEvent {
       }
       return { kind: 'write', path: filePath, content, output: event.output }
     }
+    case 'replace_string_in_file': {
+      const { filePath, newString } = event.input as {
+        filePath: string
+        newString: string
+      }
+      return {
+        kind: 'write',
+        path: filePath,
+        content: newString,
+        output: event.output,
+      }
+    }
     default:
       return {
         kind: 'other',

--- a/src/vendors/github-copilot/event.test.ts
+++ b/src/vendors/github-copilot/event.test.ts
@@ -42,6 +42,23 @@ describe('toCanonical (github-copilot)', () => {
     })
   })
 
+  it('classifies an edit action as a write event using new_str as content', () => {
+    const result = toCanonical({
+      kind: 'action',
+      tool: 'edit',
+      input: { path: '/abs/src/calc.ts', old_str: 'old', new_str: 'new' },
+      output: 'edited',
+      toolUseId: 'call_edit',
+    })
+
+    expect(result).toEqual({
+      kind: 'write',
+      path: '/abs/src/calc.ts',
+      content: 'new',
+      output: 'edited',
+    })
+  })
+
   it('classifies an unrecognized tool as an other event, preserving raw input', () => {
     const result = toCanonical({
       kind: 'action',

--- a/src/vendors/github-copilot/event.ts
+++ b/src/vendors/github-copilot/event.ts
@@ -14,6 +14,10 @@ export function toCanonical(event: RawSessionEvent): SessionEvent {
       }
       return { kind: 'write', path, content: file_text, output: event.output }
     }
+    case 'edit': {
+      const { path, new_str } = event.input as { path: string; new_str: string }
+      return { kind: 'write', path, content: new_str, output: event.output }
+    }
     default:
       return {
         kind: 'other',


### PR DESCRIPTION
## Problem

`toCanonical` in `github-copilot` and `github-copilot-chat` doesn't classify edit-style tool actions (`edit` and `replace_string_in_file`) as `kind: 'write'`. They fall through to `kind: 'other'`, making them invisible to rules that read canonical history.

`claude-code` already handles its `Edit` tool symmetrically (`src/vendors/claude-code/event.ts:17-28`). This PR brings the Copilot vendors in line.

## Why this matters

`requireCommand` (`src/rules/require-command.ts:69-86`) reads canonical history and treats only `event.kind === 'write'` as invalidating its gate. With Copilot, a `replace_string_in_file` or `edit` between the required command and the gated command does not invalidate the gate, producing a behavior gap relative to claude-code for an otherwise identical config.

`enforceTdd` is not affected because it reads `ctx.rawHistory()` rather than the canonical timeline.

## Changes

- `src/vendors/github-copilot-chat/event.ts`: add `replace_string_in_file` case, mapping to `kind: 'write'` with `newString` as `content`.
- `src/vendors/github-copilot/event.ts`: add `edit` case, mapping to `kind: 'write'` with `new_str` as `content`.
- Matching tests added in each vendor's `event.test.ts`.

Both follow the existing `claude-code` `Edit` case shape (`src/vendors/claude-code/event.ts:17-28`).

## Tests

- `npm run checks` is green (365 tests pass, 15 skipped).

Closes #18.