### PR TITLE
fix(enforce-tdd): distinguish unreadable before-content from missing files

### DIFF
--- a/src/rules/enforce-tdd.test.ts
+++ b/src/rules/enforce-tdd.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -172,6 +172,73 @@ describe('enforce-tdd', () => {
     )
 
     expect(s.capturedPrompt).toContain('export const previous = 1')
+  })
+
+  it('tells the AI a path is unreadable rather than absent when it resolves through a symlink (O_NOFOLLOW refuses the open but the file is really there)', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'enforce-tdd-symlink-'))
+    onTestFinished(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+    const realPath = path.join(dir, 'real-test.ts')
+    const linkPath = path.join(dir, 'link-test.ts')
+    await writeFile(realPath, `describe('x', () => { it('a', () => {}) })\n`)
+    await symlink(realPath, linkPath)
+    const s = setup()
+
+    await s.rule(
+      {
+        kind: 'write',
+        path: linkPath,
+        content: `describe('x', () => { it('a', () => {}); it('b', () => {}) })\n`,
+      },
+      s.ctx,
+    )
+
+    const fileSection = sectionAfter(
+      s.capturedPrompt,
+      '## Current file content',
+    )
+    expect(fileSection).not.toMatch(/file does not exist/i)
+    expect(fileSection).toMatch(/unreadable|inaccessible/i)
+  })
+
+  it('does not fast-path a write through a symlink even when the post-edit content has a single test (before-content is unknown so the diff is unverifiable)', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'enforce-tdd-symlink-fp-'))
+    onTestFinished(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+    const realPath = path.join(dir, 'real-empty-test.ts')
+    const linkPath = path.join(dir, 'link-empty-test.ts')
+    await writeFile(realPath, '')
+    await symlink(realPath, linkPath)
+    const s = setup()
+
+    await s.rule(
+      {
+        kind: 'write',
+        path: linkPath,
+        content: `describe('x', () => { it('a', () => {}) })\n`,
+      },
+      s.ctx,
+    )
+
+    expect(s.agentCalled).toBe(true)
+  })
+
+  it('still tells the AI "(file does not exist)" when the path genuinely has no file there', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'enforce-tdd-missing-'))
+    onTestFinished(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+    const filePath = path.join(dir, 'never-created.ts')
+    const s = setup()
+
+    await s.rule(
+      { kind: 'write', path: filePath, content: 'export const fresh = 1' },
+      s.ctx,
+    )
+
+    expect(s.capturedPrompt).toMatch(/file does not exist/i)
   })
 
   it('renders object event inputs without escape noise', async () => {
@@ -363,4 +430,12 @@ function writeAction(
   content = 'export const add = (a, b) => a + b',
 ): Action {
   return { kind: 'write', path, content }
+}
+
+function sectionAfter(prompt: string, heading: string): string {
+  const start = prompt.indexOf(heading)
+  if (start < 0) throw new Error(`heading not found: ${heading}`)
+  const body = prompt.slice(start + heading.length)
+  const next = body.indexOf('\n## ')
+  return next < 0 ? body : body.slice(0, next)
 }

--- a/src/rules/enforce-tdd.ts
+++ b/src/rules/enforce-tdd.ts
@@ -120,19 +120,27 @@ function formatInput(input: unknown): string {
   return JSON.stringify(input)
 }
 
+// `present`: file exists and we could read it. `absent`: path resolves to
+// nothing on disk (genuine new-file write). `unreadable`: path resolves to
+// something, but the defenses (`O_NOFOLLOW` for symlinks,
+// `MAX_BEFORE_CONTENT_BYTES` for oversize, any other open/stat/read error)
+// refused to surface its content. The three were collapsed into a single
+// `undefined` return before, which made the validator think a symlinked or
+// oversized file did not exist.
+type BeforeContent =
+  | { kind: 'present'; content: string }
+  | { kind: 'absent' }
+  | { kind: 'unreadable' }
+
 function buildPrompt(
   rules: string,
   historyBlock: string,
-  beforeContent: string | undefined,
+  before: BeforeContent,
   action: { path: string; content: string },
 ): string {
   const sections = [PROCESS_INSTRUCTIONS, rules]
   if (historyBlock) sections.push(`## Recent session\n\n${historyBlock}`)
-  sections.push(
-    beforeContent === undefined
-      ? `## Current file content\n\n(file does not exist)`
-      : `## Current file content\n\n${beforeContent}`,
-  )
+  sections.push(`## Current file content\n\n${formatBefore(before)}`)
   sections.push(
     `## Pending action\n\nFile: ${action.path}\n\n${action.content}`,
   )
@@ -140,22 +148,42 @@ function buildPrompt(
   return sections.join('\n\n')
 }
 
-async function readBeforeContent(path: string): Promise<string | undefined> {
+function formatBefore(before: BeforeContent): string {
+  switch (before.kind) {
+    case 'present':
+      return before.content
+    case 'absent':
+      return '(file does not exist)'
+    case 'unreadable':
+      return '(current file content is unreadable: the path resolves to something on disk but could not be opened — likely a symbolic link, a file over the size cap, or otherwise inaccessible)'
+  }
+}
+
+async function readBeforeContent(path: string): Promise<BeforeContent> {
   let handle
   try {
     handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW)
-  } catch {
-    return undefined
+  } catch (error) {
+    if (isErrnoCode(error, 'ENOENT')) return { kind: 'absent' }
+    return { kind: 'unreadable' }
   }
   try {
     const info = await handle.stat()
-    if (info.size > MAX_BEFORE_CONTENT_BYTES) return undefined
-    return await handle.readFile('utf8')
+    if (info.size > MAX_BEFORE_CONTENT_BYTES) return { kind: 'unreadable' }
+    return { kind: 'present', content: await handle.readFile('utf8') }
   } catch {
-    return undefined
+    return { kind: 'unreadable' }
   } finally {
     await handle.close()
   }
+}
+
+function isErrnoCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as { code: unknown }).code === code
+  )
 }
 
 /**
@@ -222,27 +250,32 @@ export function enforceTdd(
   const fastPath = options.fastPath ?? true
   return async (action: Action, ctx?: RuleContext): Promise<RuleResult> => {
     if (action.kind !== 'write') return { kind: 'pass' }
-    const beforeContent = await readBeforeContent(action.path)
-    if (fastPath && isSingleNewTest(action, beforeContent)) {
+    const before = await readBeforeContent(action.path)
+    if (fastPath && isSingleNewTest(action, before)) {
       return { kind: 'pass' }
     }
-    return validateWithAi(action, ctx, beforeContent, rules, window)
+    return validateWithAi(action, ctx, before, rules, window)
   }
 }
 
+// The fast-path is a deterministic check on `count_after - count_before === 1`.
+// `unreadable` leaves `count_before` unknowable, so any delta we compute is
+// unverifiable; fall through to the AI rather than risk a false-pass.
 function isSingleNewTest(
   action: { path: string; content: string },
-  beforeContent: string | undefined,
+  before: BeforeContent,
 ): boolean {
+  if (before.kind === 'unreadable') return false
   const language = inferLanguage(action.path)
   if (!language) return false
-  return countNewTestNodes(beforeContent ?? '', action.content, language) === 1
+  const beforeText = before.kind === 'present' ? before.content : ''
+  return countNewTestNodes(beforeText, action.content, language) === 1
 }
 
 async function validateWithAi(
   action: { path: string; content: string },
   ctx: RuleContext | undefined,
-  beforeContent: string | undefined,
+  before: BeforeContent,
   rules: string,
   window: HistoryWindow,
 ): Promise<RuleResult> {
@@ -256,7 +289,7 @@ async function validateWithAi(
   const events = (await ctx.rawHistory?.()) ?? []
   const windowed = trimHistory(events, window)
   const historyBlock = windowed.map(formatEvent).join('\n')
-  const prompt = buildPrompt(rules, historyBlock, beforeContent, action)
+  const prompt = buildPrompt(rules, historyBlock, before, action)
   const verdict = await ctx.agent.reason(prompt)
   if (verdict.kind === 'violation') {
     return { kind: 'violation', reason: verdict.reason }


### PR DESCRIPTION
## Problem

`readBeforeContent` returns `undefined` for three distinct outcomes — the path resolves to no file on disk, `O_NOFOLLOW` refused to follow a symlink at the path, and the file at the path is over `MAX_BEFORE_CONTENT_BYTES`. Both downstream consumers (`isSingleNewTest`, the AI prompt) read `undefined` only as "file does not exist."

Two failures follow:

- The AI prompt's "Current file content" section reads `(file does not exist)` for files that do exist on disk but were defended away from being read. The validator judges a wrong picture.
- The fast-path computes the before / after test-count delta against an assumed-empty pre-image when the real pre-image is unreadable. Either fast-path-passes a diff it cannot verify, or falls through to the AI with a delta that does not match reality.

Sibling `src/utils/read-jsonl.ts:6-11` already refuses symlinks / oversize files explicitly with a thrown error and a clear message. The TDD pre-read should align with that intent without dropping its safeguards.

## Fix

- `readBeforeContent` returns a discriminated `BeforeContent` of `present | absent | unreadable`. `ENOENT` still maps to `absent`, so genuine new-file writes are unaffected.
- `isSingleNewTest` returns false on `unreadable` so the fast-path falls through to the AI — consistent with ADR-0006: *"deterministic gate can pass but never block; only the AI can block."*
- The prompt's file-content section reports the file as unreadable rather than absent so the validator can reason about the actual situation.

## Reproduction

With a stub agent that always returns `violation` and `enforceTdd()`:

- Before: a Write through a symlink to an empty file with single-test content gets `permissionDecision: allow` via fast-path — the agent slips past TDD without ever reaching the AI.
- After: same write falls through to AI and the stub blocks it (`permissionDecision: deny`).

## Tests

- Symlinked path: AI prompt's file-content section reports `unreadable` rather than `(file does not exist)`.
- Symlinked path: fast-path is suppressed even when post-edit content has a single new test (before-content unverifiable).
- Genuine missing file: still reads `(file does not exist)` — regression check for existing behavior.

`npm run checks` — green (425 pass, 16 skipped).