### PR TITLE
fix(adapters): drop blocked file-write attempts from recent history

### DIFF
--- a/src/vendors/claude-code/transcript.test.ts
+++ b/src/vendors/claude-code/transcript.test.ts
@@ -52,6 +52,32 @@ describe('claude-code transcript', () => {
     expect(events).toEqual([{ kind: 'prompt', text: 'hello' }])
   })
 
+  it('drops Edit/Write tool calls whose tool_result was an error (e.g. blocked by a hook), since the file did not actually change', async () => {
+    const events = await readTranscript(
+      'test/fixtures/transcripts/blocked-edit.jsonl',
+    )
+
+    expect(events).toContainEqual({
+      kind: 'action',
+      tool: 'Bash',
+      input: { command: 'npm test' },
+      output: '1 test failed',
+      toolUseId: 'tu_bash',
+    })
+    expect(events).toContainEqual({
+      kind: 'action',
+      tool: 'Edit',
+      input: { file_path: 'src/calc.ts', old_string: 'a', new_string: 'b' },
+      output: 'The file has been updated successfully',
+      toolUseId: 'tu_edit_kept',
+    })
+    expect(
+      events.find(
+        (e) => e.kind === 'action' && e.toolUseId === 'tu_edit_blocked',
+      ),
+    ).toBeUndefined()
+  })
+
   it('returns events in the order they appear in the transcript', async () => {
     const events = await readTranscript(
       'test/fixtures/transcripts/interleaved.jsonl',

--- a/src/vendors/claude-code/transcript.ts
+++ b/src/vendors/claude-code/transcript.ts
@@ -14,12 +14,15 @@ const ContentItemSchema = z.discriminatedUnion('type', [
     type: z.literal('tool_result'),
     content: z.string(),
     tool_use_id: z.string(),
+    is_error: z.boolean().optional(),
   }),
   z.object({
     type: z.literal('text'),
     text: z.string(),
   }),
 ])
+
+const FILE_WRITE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit'])
 
 const EntrySchema = z.object({
   type: z.string().optional(),
@@ -33,6 +36,7 @@ export async function readTranscript(
   const entries = await readJsonl(path, options)
   const pending = new Map<string, RawSessionEvent>()
   const emitted: RawSessionEvent[] = []
+  const droppedToolUseIds = new Set<string>()
 
   for (const rawEntry of entries) {
     const entry = EntrySchema.safeParse(rawEntry)
@@ -57,11 +61,17 @@ export async function readTranscript(
         const existing = pending.get(item.tool_use_id)
         if (existing && existing.kind === 'action') {
           existing.output = item.content
+          if (item.is_error === true && FILE_WRITE_TOOLS.has(existing.tool)) {
+            droppedToolUseIds.add(item.tool_use_id)
+          }
         }
       } else if (item.type === 'text' && entry.data.type === 'user') {
         emitted.push({ kind: 'prompt', text: item.text })
       }
     }
   }
-  return emitted
+  return emitted.filter(
+    (event) =>
+      event.kind !== 'action' || !droppedToolUseIds.has(event.toolUseId),
+  )
 }

--- a/src/vendors/github-copilot/transcript.test.ts
+++ b/src/vendors/github-copilot/transcript.test.ts
@@ -27,6 +27,32 @@ describe('github-copilot transcript', () => {
     expect(bashAction.toolUseId).toMatch(/^call_/)
   })
 
+  it('drops create/edit tool calls whose tool.execution_complete reports success: false (e.g. denied by a hook), since the file did not actually change', async () => {
+    const events = await readTranscript(
+      'test/fixtures/transcripts/copilot-blocked-edit.jsonl',
+    )
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: 'action',
+        tool: 'bash',
+        toolUseId: 'call_bash',
+      }),
+    )
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: 'action',
+        tool: 'edit',
+        toolUseId: 'call_edit_kept',
+      }),
+    )
+    expect(
+      events.find(
+        (e) => e.kind === 'action' && e.toolUseId === 'call_edit_blocked',
+      ),
+    ).toBeUndefined()
+  })
+
   it('returns events in the order they appear in the transcript', async () => {
     const events = await readTranscript(
       'test/fixtures/transcripts/copilot-basic.jsonl',

--- a/src/vendors/github-copilot/transcript.ts
+++ b/src/vendors/github-copilot/transcript.ts
@@ -21,14 +21,23 @@ const ToolCompleteSchema = z.object({
   type: z.literal('tool.execution_complete'),
   data: z.object({
     toolCallId: z.string(),
+    success: z.boolean().optional(),
     result: z
       .object({
         content: z.string().optional(),
         detailedContent: z.string().optional(),
       })
       .optional(),
+    error: z
+      .object({
+        message: z.string().optional(),
+        code: z.string().optional(),
+      })
+      .optional(),
   }),
 })
+
+const FILE_WRITE_TOOLS = new Set(['create', 'edit'])
 
 export async function readTranscript(
   path: string,
@@ -37,6 +46,7 @@ export async function readTranscript(
   const entries = await readJsonl(path, options)
   const pending = new Map<string, RawSessionEvent>()
   const emitted: RawSessionEvent[] = []
+  const droppedToolUseIds = new Set<string>()
   for (const rawEntry of entries) {
     const user = UserMessageSchema.safeParse(rawEntry)
     if (user.success) {
@@ -63,9 +73,19 @@ export async function readTranscript(
         existing.output =
           complete.data.data.result?.content ??
           complete.data.data.result?.detailedContent ??
+          complete.data.data.error?.message ??
           ''
+        if (
+          complete.data.data.success === false &&
+          FILE_WRITE_TOOLS.has(existing.tool)
+        ) {
+          droppedToolUseIds.add(complete.data.data.toolCallId)
+        }
       }
     }
   }
-  return emitted
+  return emitted.filter(
+    (event) =>
+      event.kind !== 'action' || !droppedToolUseIds.has(event.toolUseId),
+  )
 }

--- a/test/fixtures/transcripts/blocked-edit.jsonl
+++ b/test/fixtures/transcripts/blocked-edit.jsonl
@@ -1,0 +1,7 @@
+{"type":"user","message":{"content":[{"type":"text","text":"add a header field"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_bash","name":"Bash","input":{"command":"npm test"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_bash","content":"1 test failed","is_error":true}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_edit_kept","name":"Edit","input":{"file_path":"src/calc.ts","old_string":"a","new_string":"b"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_edit_kept","content":"The file has been updated successfully"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_edit_blocked","name":"Edit","input":{"file_path":"src/calc.ts","old_string":"b","new_string":"c"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_edit_blocked","content":"no failing test for this change","is_error":true}]}}

--- a/test/fixtures/transcripts/copilot-blocked-edit.jsonl
+++ b/test/fixtures/transcripts/copilot-blocked-edit.jsonl
@@ -1,0 +1,7 @@
+{"type":"user.message","data":{"content":"add a header field"}}
+{"type":"tool.execution_start","data":{"toolCallId":"call_bash","toolName":"bash","arguments":{"command":"npm test"}}}
+{"type":"tool.execution_complete","data":{"toolCallId":"call_bash","success":false,"result":{"content":"1 test failed"}}}
+{"type":"tool.execution_start","data":{"toolCallId":"call_edit_kept","toolName":"edit","arguments":{"path":"src/calc.ts","old_str":"a","new_str":"b"}}}
+{"type":"tool.execution_complete","data":{"toolCallId":"call_edit_kept","success":true,"result":{"content":"The file has been updated successfully"}}}
+{"type":"tool.execution_start","data":{"toolCallId":"call_edit_blocked","toolName":"edit","arguments":{"path":"src/calc.ts","old_str":"b","new_str":"c"}}}
+{"type":"tool.execution_complete","data":{"toolCallId":"call_edit_blocked","success":false,"error":{"message":"no failing test for this change","code":"denied"}}}


### PR DESCRIPTION
Fixes #24.

## Problem

`enforceTdd`'s judge sees its own prior rejection messages in the recent-session history. When a hook denies a file-write tool call, the agent's transcript records the rejection with a clear error marker (Claude Code: `is_error: true`; GitHub Copilot CLI: `success: false` + `error.code: "denied"`). The judge anchors on those past rejections, confabulates a wrong session summary, and keeps blocking even when the actual failing test sits in the same prompt.

## Fix

In the affected vendor transcript readers, drop file-write tool calls whose result is marked as an error/denial. A blocked write produced no file change, so it isn't evidence of work done — only noise the judge can latch onto.

- **claude-code:** drop `Edit`/`Write`/`MultiEdit`/`NotebookEdit` calls whose `tool_result.is_error === true`.
- **github-copilot:** drop `create`/`edit` calls whose `tool.execution_complete.success === false`.

Bash with the same error markers is kept — non-zero exits from test runners are exactly the failing-test signal the judge needs.

## Vendor coverage

- `claude-code` — covered
- `github-copilot` — covered
- `codex` — no obvious structured error marker on `function_call_output` (`{call_id, output: string}` only); needs a real blocked-call transcript to know what shape to filter. Follow-up PR.
- `github-copilot-chat` — tool outputs come from a delta stream; needs separate investigation. Follow-up PR.

## Verification

- Legit retry after a prior block → now allowed.
- Implementation without any failing test → still blocked.
- Bash test failures still surface in history.
- Full Probity test suite passes (365 tests).

## Changes

- `src/vendors/claude-code/transcript.ts` — recognise `is_error`; drop blocked file-writes.
- `src/vendors/claude-code/transcript.test.ts` — pin the behaviour.
- `test/fixtures/transcripts/blocked-edit.jsonl` — claude-code fixture.
- `src/vendors/github-copilot/transcript.ts` — recognise `success`/`error`; drop blocked file-writes.
- `src/vendors/github-copilot/transcript.test.ts` — pin the behaviour.
- `test/fixtures/transcripts/copilot-blocked-edit.jsonl` — copilot fixture.
