### PR TITLE
feat(matchers): add PHP language support for the enforceTdd fast-path

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -70,6 +70,7 @@ When a write to a recognised language adds exactly one new test node, the rule r
 | Python     | `.py`         | `@ast-grep/lang-python` | `def test_*` (pytest convention)                                         |
 | C#         | `.cs`         | `@ast-grep/lang-csharp` | `[Fact]` / `[Theory]` (xUnit), `[Test]` (NUnit), `[TestMethod]` (MSTest) |
 | Ruby       | `.rb`         | `@ast-grep/lang-ruby`   | `it` / `specify` / `xit` / `fit` (RSpec), `def test_*` (Minitest)        |
+| PHP        | `.php`        | `@ast-grep/lang-php`    | `function test*` (prefix), `#[Test]` attribute, `@test` PHPDoc (PHPUnit) |
 
 Languages with a "Required pack" entry need the corresponding `@ast-grep/lang-*` package installed in the **same scope** as Probity. Use `npm install -D <pack>` for project-local or `npm install -g <pack>` for global. If the pack isn't installed, writes in that language silently fall through to the AI path (no install, no error, no fast-path).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@ast-grep/lang-csharp": "^0.0.6",
+        "@ast-grep/lang-php": "^0.0.7",
         "@ast-grep/lang-python": "^0.0.6",
         "@ast-grep/lang-ruby": "^0.0.7",
         "@commitlint/cli": "^20.5.0",
@@ -212,6 +213,25 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@ast-grep/lang-csharp/-/lang-csharp-0.0.6.tgz",
       "integrity": "sha512-9Aq0WvJ5wRdJ+iply7H2Aq89o2BOdxFXh3H9tLvf8DryyHgWAQA/CRKUw1HjV8Q4ABUZFl1vLq9Uv3t0gQtZdQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "@ast-grep/setup-lang": "0.0.6"
+      },
+      "peerDependencies": {
+        "tree-sitter-cli": "0.25.8"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ast-grep/lang-php": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@ast-grep/lang-php/-/lang-php-0.0.7.tgz",
+      "integrity": "sha512-cDCcgSRj4eL8QnEivUbxYVSUn4PESyLdp6RuFvYw2gMOb8qzfR1FTq503D9tZ5pqvZCALR3KrbVNzc8SHaQs7Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "ISC",
@@ -747,29 +767,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1661,6 +1658,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1717,6 +1715,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2034,6 +2033,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2546,6 +2546,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2817,6 +2818,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3065,6 +3067,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3449,6 +3452,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3683,6 +3687,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5140,6 +5145,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5213,6 +5219,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5596,6 +5603,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,11 +44,15 @@
       },
       "peerDependencies": {
         "@ast-grep/lang-csharp": "*",
+        "@ast-grep/lang-php": "*",
         "@ast-grep/lang-python": "*",
         "@ast-grep/lang-ruby": "*"
       },
       "peerDependenciesMeta": {
         "@ast-grep/lang-csharp": {
+          "optional": true
+        },
+        "@ast-grep/lang-php": {
           "optional": true
         },
         "@ast-grep/lang-python": {
@@ -767,6 +771,29 @@
         "conventional-commits-parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@ast-grep/lang-csharp": "^0.0.6",
+    "@ast-grep/lang-php": "^0.0.7",
     "@ast-grep/lang-python": "^0.0.6",
     "@ast-grep/lang-ruby": "^0.0.7",
     "@commitlint/cli": "^20.5.0",
@@ -91,11 +92,15 @@
   },
   "peerDependencies": {
     "@ast-grep/lang-csharp": "*",
+    "@ast-grep/lang-php": "*",
     "@ast-grep/lang-python": "*",
     "@ast-grep/lang-ruby": "*"
   },
   "peerDependenciesMeta": {
     "@ast-grep/lang-csharp": {
+      "optional": true
+    },
+    "@ast-grep/lang-php": {
       "optional": true
     },
     "@ast-grep/lang-python": {

--- a/src/rules/matchers/count-new-test-nodes.test.ts
+++ b/src/rules/matchers/count-new-test-nodes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { countNewTestNodes } from './count-new-test-nodes.js'
 import { csharp } from './languages/csharp.js'
 import { javascript } from './languages/javascript.js'
+import { php } from './languages/php.js'
 import { python } from './languages/python.js'
 import { ruby } from './languages/ruby.js'
 import { typescript } from './languages/typescript.js'
@@ -292,5 +293,77 @@ describe('countNewTestNodes (ruby)', () => {
     const after = `describe 'Calc' do\nend\n`
 
     expect(countNewTestNodes(before, after, ruby)).toBe(0)
+  })
+})
+
+describe('countNewTestNodes (php)', () => {
+  it('counts a public function test_*() method (PHPUnit prefix) as a new test node', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  public function test_addition() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(1)
+  })
+
+  it('counts a public function testFoo() camelCase method as a new test node', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  public function testAddition() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(1)
+  })
+
+  it('counts a method with the #[Test] PHP 8 attribute as a new test node', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  #[Test]\n  public function it_adds() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(1)
+  })
+
+  it('counts a method with the @test PHPDoc annotation as a new test node', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  /** @test */\n  public function it_adds() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(1)
+  })
+
+  it('returns 0 when an existing test method is renamed but no test is added', () => {
+    const before = `<?php\nclass CalcTest {\n  public function test_adds() {}\n}\n`
+    const after = `<?php\nclass CalcTest {\n  public function test_adds_two_numbers() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(0)
+  })
+
+  it('returns 2 when two test methods are added in a single change', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  public function test_adds() {}\n  public function test_subtracts() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(2)
+  })
+
+  it('counts a method with both #[Test] and a test_ prefix only once', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  #[Test]\n  public function test_dual() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(1)
+  })
+
+  it('does not count an empty class with no test methods as a test node', () => {
+    const before = ``
+    const after = `<?php\nclass CalcTest {}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(0)
+  })
+
+  it('does not count a #[DataProvider] attribute as a test node', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  #[DataProvider('cases')]\n  public function provideCases(): array { return []; }\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(0)
+  })
+
+  it('does not count a @testWith PHPDoc as a test node by itself', () => {
+    const before = `<?php\nclass CalcTest {}\n`
+    const after = `<?php\nclass CalcTest {\n  /** @testWith [1, 2] */\n  public function provideCases() {}\n}\n`
+
+    expect(countNewTestNodes(before, after, php)).toBe(0)
   })
 })

--- a/src/rules/matchers/languages/index.test.ts
+++ b/src/rules/matchers/languages/index.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest'
 import { csharp } from './csharp.js'
 import { inferLanguage } from './index.js'
 import { javascript } from './javascript.js'
+import { php } from './php.js'
 import { python } from './python.js'
 import { ruby } from './ruby.js'
 import { typescript } from './typescript.js'
@@ -32,8 +33,12 @@ describe('inferLanguage', () => {
     expect(inferLanguage('spec/foo_spec.rb')).toBe(ruby)
   })
 
+  it('returns the php module for a .php file', () => {
+    expect(inferLanguage('tests/FooTest.php')).toBe(php)
+  })
+
   it('returns a registered language for any extension declared on its module', () => {
-    for (const lang of [typescript, javascript, python, csharp, ruby]) {
+    for (const lang of [typescript, javascript, python, csharp, ruby, php]) {
       for (const ext of lang.extensions) {
         expect(inferLanguage(`src/foo${ext}`)).toBe(lang)
       }

--- a/src/rules/matchers/languages/index.ts
+++ b/src/rules/matchers/languages/index.ts
@@ -2,11 +2,12 @@ import path from 'node:path'
 
 import { csharp } from './csharp.js'
 import { javascript } from './javascript.js'
+import { php } from './php.js'
 import { python } from './python.js'
 import { ruby } from './ruby.js'
 import { typescript } from './typescript.js'
 
-const REGISTRY = [typescript, javascript, python, csharp, ruby] as const
+const REGISTRY = [typescript, javascript, python, csharp, ruby, php] as const
 
 export function inferLanguage(filePath: string) {
   const ext = path.extname(filePath)

--- a/src/rules/matchers/languages/php.ts
+++ b/src/rules/matchers/languages/php.ts
@@ -1,0 +1,25 @@
+import { isRegistered } from './register.js'
+
+export const php = {
+  name: 'php',
+  extensions: ['.php'],
+  parser: isRegistered('php') ? 'php' : undefined,
+  patterns: [
+    {
+      rule: {
+        kind: 'method_declaration',
+        any: [
+          { has: { field: 'name', regex: '^test' } },
+          {
+            has: {
+              stopBy: 'end' as const,
+              kind: 'attribute',
+              regex: '^Test(\\(|$)',
+            },
+          },
+          { follows: { kind: 'comment', regex: '@test\\b' } },
+        ],
+      },
+    },
+  ],
+}

--- a/src/rules/matchers/languages/register.test.ts
+++ b/src/rules/matchers/languages/register.test.ts
@@ -15,6 +15,10 @@ describe('register', () => {
     expect(isRegistered('ruby')).toBe(true)
   })
 
+  it('reports php as registered when @ast-grep/lang-php is available', () => {
+    expect(isRegistered('php')).toBe(true)
+  })
+
   it('reports false for a language that has no peer-dep declared', () => {
     expect(isRegistered('cobol')).toBe(false)
   })

--- a/src/rules/matchers/languages/register.ts
+++ b/src/rules/matchers/languages/register.ts
@@ -11,6 +11,7 @@ const PEER_DEPS: Record<string, string> = {
   python: '@ast-grep/lang-python',
   csharp: '@ast-grep/lang-csharp',
   ruby: '@ast-grep/lang-ruby',
+  php: '@ast-grep/lang-php',
 }
 
 const registered = new Set<string>()


### PR DESCRIPTION
## Problem

`enforceTdd` fast-path covers JS / TS / Python / C# / Ruby but not PHP. PHPUnit projects always pay for AI validation even when only a single new test is added.

## Changes

New `php` matcher module wired via `inferLanguage` for `.php` files. Recognises all three PHPUnit test-method forms:

- `function test*` — name-prefix convention (`method_declaration` with `field: 'name'` matching `^test`)
- `#[Test]` / `#[Test()]` — PHP 8 attribute (`has` with `kind: 'attribute'` matching `^Test(\(|$)`)
- `/** @test */` PHPDoc annotation — comment sibling (`follows` with `kind: 'comment'` matching `@test\b`)

`@ast-grep/lang-php` is added through the existing optional peer-dep mechanism (matching the python / csharp / ruby pattern), so consumers without it fall through to AI validation rather than breaking at module load.

## Tests

- `npm run checks` — green (471 pass, 16 skipped)
- 10 new cases in `count-new-test-nodes.test.ts`: `test_*` prefix → 1, `testFoo` camelCase → 1, `#[Test]` attribute → 1, `@test` PHPDoc → 1, rename existing → 0, two new tests → 2, both markers on same method counted once → 1, empty class → 0, `#[DataProvider]` → 0, `@testWith` partial-match guarded → 0

## Context

Closes #15. Follows the same structure as the Ruby PR (#11).