### PR TITLE
feat: add gemini-cli transcript parser and event classifier

### DIFF
--- a/src/vendors/gemini-cli/event.test.ts
+++ b/src/vendors/gemini-cli/event.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { toCanonical } from './event.js'
+
+describe('gemini-cli event classification', () => {
+  it('maps run_shell_command to command event', () => {
+    const canonical = toCanonical({
+      kind: 'action',
+      tool: 'run_shell_command',
+      input: { command: 'ls' },
+      output: 'file.txt',
+      toolUseId: 'id1',
+    })
+    expect(canonical).toEqual({
+      kind: 'command',
+      command: 'ls',
+      output: 'file.txt',
+    })
+  })
+
+  it('maps write_file to write event', () => {
+    const canonical = toCanonical({
+      kind: 'action',
+      tool: 'write_file',
+      input: { file_path: 'foo.txt', content: 'hello' },
+      output: 'ok',
+      toolUseId: 'id2',
+    })
+    expect(canonical).toEqual({
+      kind: 'write',
+      path: 'foo.txt',
+      content: 'hello',
+      output: 'ok',
+    })
+  })
+
+  it('maps replace to write event', () => {
+    const canonical = toCanonical({
+      kind: 'action',
+      tool: 'replace',
+      input: { file_path: 'foo.txt', new_string: 'world' },
+      output: 'ok',
+      toolUseId: 'id3',
+    })
+    expect(canonical).toEqual({
+      kind: 'write',
+      path: 'foo.txt',
+      content: 'world',
+      output: 'ok',
+    })
+  })
+
+  it('maps other tools to other event', () => {
+    const canonical = toCanonical({
+      kind: 'action',
+      tool: 'list_directory',
+      input: { dir_path: '.' },
+      output: '...',
+      toolUseId: 'id4',
+    })
+    expect(canonical).toEqual({
+      kind: 'other',
+      tool: 'list_directory',
+      input: { dir_path: '.' },
+      output: '...',
+    })
+  })
+})

--- a/src/vendors/gemini-cli/event.ts
+++ b/src/vendors/gemini-cli/event.ts
@@ -1,0 +1,37 @@
+import type { RawSessionEvent, SessionEvent } from '../../types.js'
+
+export function toCanonical(event: RawSessionEvent): SessionEvent {
+  if (event.kind === 'prompt') return event
+  switch (event.tool) {
+    case 'run_shell_command': {
+      const { command } = event.input as { command: string }
+      return { kind: 'command', command, output: event.output }
+    }
+    case 'write_file': {
+      const { file_path, content } = event.input as {
+        file_path: string
+        content: string
+      }
+      return { kind: 'write', path: file_path, content, output: event.output }
+    }
+    case 'replace': {
+      const { file_path, new_string } = event.input as {
+        file_path: string
+        new_string: string
+      }
+      return {
+        kind: 'write',
+        path: file_path,
+        content: new_string,
+        output: event.output,
+      }
+    }
+    default:
+      return {
+        kind: 'other',
+        tool: event.tool,
+        input: event.input,
+        output: event.output,
+      }
+  }
+}

--- a/src/vendors/gemini-cli/transcript.test.ts
+++ b/src/vendors/gemini-cli/transcript.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { readTranscript } from './transcript.js'
+
+describe('gemini-cli transcript', () => {
+  it('parses user prompts and gemini tool calls', async () => {
+    const events = await readTranscript(
+      'test/fixtures/gemini-cli/session-sample.jsonl',
+    )
+
+    expect(events).toEqual([
+      { kind: 'prompt', text: 'Hello' },
+      {
+        kind: 'action',
+        tool: 'list_directory',
+        input: { dir_path: 'src' },
+        output: 'src/index.ts',
+        toolUseId: 'tool-1',
+      },
+      { kind: 'prompt', text: 'Next step' },
+    ])
+  })
+
+  it('handles gemini text responses (non-tool calls) as non-events', async () => {
+    const events = await readTranscript(
+      'test/fixtures/gemini-cli/session-sample.jsonl',
+    )
+    // We only care about prompts and actions for now, consistent with other vendors.
+    // Text responses from the AI are usually not events rules reason about.
+    expect(events.filter((e) => e.kind === 'prompt')).toHaveLength(2)
+  })
+})

--- a/src/vendors/gemini-cli/transcript.ts
+++ b/src/vendors/gemini-cli/transcript.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod'
+import type { RawSessionEvent } from '../../types.js'
+import { readJsonl } from '../../utils/read-jsonl.js'
+
+const UserMessageSchema = z.object({
+  type: z.literal('user'),
+  content: z.array(z.object({ text: z.string() })),
+})
+
+const GeminiMessageSchema = z.object({
+  type: z.literal('gemini'),
+  toolCalls: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        args: z.unknown(),
+        result: z.array(z.unknown()).optional(),
+      }),
+    )
+    .optional(),
+})
+
+export async function readTranscript(
+  path: string,
+  options: { maxBytes?: number } = {},
+): Promise<RawSessionEvent[]> {
+  const entries = await readJsonl(path, options)
+  const emitted: RawSessionEvent[] = []
+
+  for (const entry of entries) {
+    const user = UserMessageSchema.safeParse(entry)
+    if (user.success) {
+      const text = user.data.content.map((c) => c.text).join('\n')
+      emitted.push({ kind: 'prompt', text })
+      continue
+    }
+
+    const gemini = GeminiMessageSchema.safeParse(entry)
+    if (gemini.success && gemini.data.toolCalls) {
+      for (const call of gemini.data.toolCalls) {
+        const output = extractToolOutput(call.result)
+        emitted.push({
+          kind: 'action',
+          tool: call.name,
+          input: call.args,
+          output,
+          toolUseId: call.id,
+        })
+      }
+    }
+  }
+
+  return emitted
+}
+
+function extractToolOutput(result: unknown[] | undefined): string {
+  if (!result || !Array.isArray(result) || result.length === 0) return ''
+  const first = result[0]
+  if (!isPlainObject(first)) return ''
+
+  const functionResponse = first['functionResponse']
+  if (!isPlainObject(functionResponse)) return ''
+
+  const response = functionResponse['response']
+  if (!isPlainObject(response)) return ''
+
+  const output = response['output']
+  return typeof output === 'string' ? output : ''
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/test/fixtures/gemini-cli/session-sample.jsonl
+++ b/test/fixtures/gemini-cli/session-sample.jsonl
@@ -1,0 +1,5 @@
+{"sessionId":"89d85314-c995-4126-be50-8166eb01d6cb","projectHash":"f3d572f3331cd82ba4f1861e338be5df93b8f8bf124f0772b33b17ace6b61e77","startTime":"2026-05-18T08:19:36.692Z","lastUpdated":"2026-05-18T08:19:36.692Z","kind":"main"}
+{"id":"user-1","timestamp":"2026-05-18T08:19:53.293Z","type":"user","content":[{"text":"Hello"}]}
+{"id":"gemini-1","timestamp":"2026-05-18T08:19:55.477Z","type":"gemini","content":"","toolCalls":[{"id":"tool-1","name":"list_directory","args":{"dir_path":"src"},"result":[{"functionResponse":{"id":"tool-1","name":"list_directory","response":{"output":"src/index.ts"}}}]}]}
+{"id":"user-2","timestamp":"2026-05-18T08:20:00.000Z","type":"user","content":[{"text":"Next step"}]}
+{"id":"gemini-2","timestamp":"2026-05-18T08:20:05.000Z","type":"gemini","content":"Done"}


### PR DESCRIPTION
This is the first PR for Gemini CLI support. It introduces:
- `transcript.ts`: Parser for Gemini CLI's JSONL session logs.
- `event.ts`: Classifier to map Gemini CLI tool calls to canonical Probity events.
- Unit tests for both.

Part of #27