### PR TITLE
fix(claude-code): evaluate NotebookEdit writes (#17)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|Write|Edit",
+        "matcher": "Bash|Write|Edit|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,7 +19,7 @@ Two commands wire probity into Claude Code's hook system, no manual config edit:
 /plugin install probity@probity
 ```
 
-The plugin ships the `PreToolUse` hook with the matcher `Bash|Write|Edit`, which covers commands and file modifications.
+The plugin ships the `PreToolUse` hook with the matcher `Bash|Write|Edit|NotebookEdit`, which covers commands and file modifications.
 
 ### Manual install
 
@@ -30,7 +30,7 @@ If you'd rather wire the hook yourself, add a `PreToolUse` entry to `.claude/set
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|Write|Edit",
+        "matcher": "Bash|Write|Edit|NotebookEdit",
         "hooks": [
           {
             "type": "command",
@@ -43,7 +43,7 @@ If you'd rather wire the hook yourself, add a `PreToolUse` entry to `.claude/set
 }
 ```
 
-The matcher controls which tools fire the hook. `Bash|Write|Edit` covers commands and file modifications.
+The matcher controls which tools fire the hook. `Bash|Write|Edit|NotebookEdit` covers commands and file modifications.
 
 Further reading: [Claude Code's hooks documentation](https://code.claude.com/docs/en/hooks).
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|Write|Edit",
+        "matcher": "Bash|Write|Edit|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/src/vendors/claude-code/adapter.test.ts
+++ b/src/vendors/claude-code/adapter.test.ts
@@ -276,11 +276,33 @@ describe('claude-code adapter', () => {
     expect(result.ok).toBe(false)
   })
 
+  it('NotebookEdit produces a write action carrying the cell source as content', async () => {
+    const result = await parseAction({
+      cwd: '/workspaces/probity',
+      tool_name: 'NotebookEdit',
+      tool_input: {
+        notebook_path: '/workspaces/probity/analysis.ipynb',
+        new_source: 'print("hello")',
+        cell_type: 'code',
+        edit_mode: 'replace',
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      action: {
+        kind: 'write',
+        path: '/workspaces/probity/analysis.ipynb',
+        content: 'print("hello")',
+      },
+    })
+  })
+
   it('passes through an unsupported tool_name as a no-op so unknown tools are not blocked', async () => {
     const action = ok(
       await parseAction({
-        tool_name: 'MultiEdit',
-        tool_input: { file_path: 'x', edits: [] },
+        tool_name: 'Grep',
+        tool_input: { pattern: 'TODO' },
       }),
     )
 

--- a/src/vendors/claude-code/adapter.test.ts
+++ b/src/vendors/claude-code/adapter.test.ts
@@ -298,6 +298,27 @@ describe('claude-code adapter', () => {
     })
   })
 
+  it('NotebookEdit with edit_mode delete carries empty content (no text is introduced)', async () => {
+    const result = await parseAction({
+      cwd: '/workspaces/probity',
+      tool_name: 'NotebookEdit',
+      tool_input: {
+        notebook_path: '/workspaces/probity/analysis.ipynb',
+        new_source: 'leftover that the delete ignores',
+        edit_mode: 'delete',
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      action: {
+        kind: 'write',
+        path: '/workspaces/probity/analysis.ipynb',
+        content: '',
+      },
+    })
+  })
+
   it('passes through an unsupported tool_name as a no-op so unknown tools are not blocked', async () => {
     const action = ok(
       await parseAction({

--- a/src/vendors/claude-code/adapter.ts
+++ b/src/vendors/claude-code/adapter.ts
@@ -50,16 +50,24 @@ export type WriteInput = z.input<typeof writeSchema>
 
 /**
  * NotebookEdit replaces, inserts, or deletes one cell of a `.ipynb`.
- * We surface it as a write whose content is the cell's `new_source` —
- * the text the agent is adding — so content rules and enforceTdd see
- * exactly what's being introduced. (Reconstructing the whole notebook
- * JSON would be faithful to disk but adds nothing the rules can use.)
+ * We surface it as a write whose content is the cell text being
+ * introduced: `new_source` for replace/insert, and empty for a delete
+ * (which introduces nothing). This is exact for content rules — they
+ * see precisely the text being added. enforceTdd is given the added
+ * cell rather than a whole-file diff: its `before` comes from reading
+ * the on-disk `.ipynb` (notebook JSON), so the comparison is cell vs.
+ * file rather than cell vs. cell. That is a known limitation for the
+ * niche of TDD-on-notebooks, and still strictly better than the prior
+ * behavior, where NotebookEdit bypassed every rule. Faithfully
+ * reconstructing the notebook JSON was rejected: it is fragile and
+ * buys nothing for the common content-rule case.
  */
 const notebookEditSchema = z.object({
   tool_name: z.literal('NotebookEdit'),
   tool_input: z.object({
     notebook_path: z.string(),
     new_source: z.string(),
+    edit_mode: z.enum(['replace', 'insert', 'delete']).optional(),
   }),
   cwd: z.string().min(1),
 })
@@ -93,7 +101,8 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
     (d): Action => ({
       kind: 'write',
       path: posixAbsolute(d.cwd, d.tool_input.notebook_path),
-      content: d.tool_input.new_source,
+      content:
+        d.tool_input.edit_mode === 'delete' ? '' : d.tool_input.new_source,
     }),
   ),
 ])

--- a/src/vendors/claude-code/adapter.ts
+++ b/src/vendors/claude-code/adapter.ts
@@ -48,6 +48,22 @@ const writeSchema = z.object({
  */
 export type WriteInput = z.input<typeof writeSchema>
 
+/**
+ * NotebookEdit replaces, inserts, or deletes one cell of a `.ipynb`.
+ * We surface it as a write whose content is the cell's `new_source` —
+ * the text the agent is adding — so content rules and enforceTdd see
+ * exactly what's being introduced. (Reconstructing the whole notebook
+ * JSON would be faithful to disk but adds nothing the rules can use.)
+ */
+const notebookEditSchema = z.object({
+  tool_name: z.literal('NotebookEdit'),
+  tool_input: z.object({
+    notebook_path: z.string(),
+    new_source: z.string(),
+  }),
+  cwd: z.string().min(1),
+})
+
 const writeToolsSchema = z.discriminatedUnion('tool_name', [
   bashSchema.transform(
     (d): Action => ({ kind: 'command', command: d.tool_input.command }),
@@ -73,17 +89,29 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
       content: d.tool_input.content,
     }),
   ),
+  notebookEditSchema.transform(
+    (d): Action => ({
+      kind: 'write',
+      path: posixAbsolute(d.cwd, d.tool_input.notebook_path),
+      content: d.tool_input.new_source,
+    }),
+  ),
 ])
 
 /**
  * Anything Claude Code fires the hook for that we don't explicitly
- * model (Read, Grep, MultiEdit, NotebookEdit, future tools) becomes a
- * no-op command: no rule matches it, the engine returns allow.
- * `passthroughFor` excludes the known tool names so a malformed
- * Bash / Edit / Write payload still surfaces as a parse error rather
- * than silently passing through.
+ * model (Read, Grep, future tools) becomes a no-op command: no rule
+ * matches it, the engine returns allow. `passthroughFor` excludes the
+ * known tool names so a malformed Bash / Edit / Write / NotebookEdit
+ * payload still surfaces as a parse error rather than silently passing
+ * through.
  */
-const passthroughSchema = passthroughFor('tool_name', ['Bash', 'Edit', 'Write'])
+const passthroughSchema = passthroughFor('tool_name', [
+  'Bash',
+  'Edit',
+  'Write',
+  'NotebookEdit',
+])
 
 export const parseAction = fromSchema(
   z.union([writeToolsSchema, passthroughSchema]),

--- a/test/integration/scenarios.e2e.test.ts
+++ b/test/integration/scenarios.e2e.test.ts
@@ -235,6 +235,37 @@ describe('install modes (claude-code)', () => {
   })
 })
 
+describe('NotebookEdit writes (claude-code)', () => {
+  it('blocks a forbidden cell so content rules fire on notebook writes', async () => {
+    const sandbox = await createSandbox({
+      'probity.config.ts': createProbityConfig({ glob: '**/*.ipynb' }),
+      'analysis.ipynb': '{"cells":[]}',
+    })
+    const payload = {
+      session_id: 'scenario',
+      transcript_path: '/tmp/transcript.jsonl',
+      cwd: sandbox.path,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'NotebookEdit',
+      tool_use_id: 'tu_scenario',
+      tool_input: {
+        notebook_path: sandbox.getPath('analysis.ipynb'),
+        new_source: CONSOLE_LOG_CONTENT,
+        edit_mode: 'replace',
+      },
+    }
+    const { stdout } = await runBin({
+      args: ['--agent', 'claude-code'],
+      payload: JSON.stringify(payload),
+      cwd: sandbox.path,
+    })
+
+    const result = decodeResponse('claude-code', stdout)
+    expect(result.decision).toBe('deny')
+    expect(result.reason).toContain(CONSOLE_RULE_REASON)
+  })
+})
+
 type Scenario = {
   glob: string
   agentCwdAt: string


### PR DESCRIPTION
Closes #17 (the NotebookEdit half; see note on MultiEdit below).

## Problem

`src/vendors/claude-code/adapter.ts` only modeled `Bash`, `Edit`, and `Write`. Every other tool name fell through `passthroughFor` to a no-op `{ kind: 'command', command: '' }` action that no rule matches — so `NotebookEdit` writes escaped `enforceTdd` and every content rule entirely. The shipped matcher (`hooks/hooks.json`), the dogfood settings, and `docs/setup.md` also matched only `Bash|Write|Edit`, so the hook was never even invoked for these payloads.

## Change

- Add a `NotebookEdit` branch to `writeToolsSchema` that surfaces the edit as a `write` whose `content` is the cell text being introduced: `new_source` for replace/insert, and empty for a `delete` (which introduces nothing). A NotebookEdit is a single-cell edit, so it maps to one `Action` and needs no `Action[]` plumbing.
- Add `NotebookEdit` to `passthroughFor`'s known tools so a malformed payload surfaces as a parse error rather than silently passing through.
- Widen the recommended/shipped matcher to `Bash|Write|Edit|NotebookEdit` (plugin hook, dogfood settings, setup docs).

### Content model and a known limitation

`content` is the introduced cell text. This is **exact for content rules** (e.g. `forbidContentPattern`) — they see precisely what's being added. For `enforceTdd` it's the added cell rather than a whole-file diff: the rule's `before` reads the on-disk `.ipynb` (notebook JSON), so the comparison is cell-vs-file, not cell-vs-cell. That's a narrow limitation for the niche of TDD-on-notebooks, documented on the schema, and still strictly better than the prior behavior where NotebookEdit bypassed every rule. Faithfully reconstructing the notebook JSON was considered and rejected: it's fragile (no real-world fixtures exist) and buys nothing for the common content-rule case.

## On MultiEdit (fact-based scoping)

#17 also named `MultiEdit`, but the original premise ("Claude Code routinely uses MultiEdit") no longer holds for current Claude Code:

- The Claude Agent SDK's `ToolInputSchemas` union has no `MultiEdit` (only `FileEditInput`, `FileWriteInput`, `NotebookEditInput`).
- Across a large local corpus of real Claude Code sessions, `MultiEdit` and `NotebookEdit` were each emitted 0 times; edits go through `Edit` and `Write`.

So MultiEdit is left unhandled rather than coded against speculatively (it would also require widening `ParseActionResult` to `Action[]`). The passthrough test's example moves off `MultiEdit` to `Grep`, a genuinely read-only tool. Happy to add defensive MultiEdit handling for older Claude Code versions if you'd prefer.

## Tests

- Adapter unit tests: NotebookEdit replace → write with `new_source`; delete → empty content.
- End-to-end: a NotebookEdit payload driven through the bin is denied by a content rule, guarding the reported regression (rules never fired on notebook writes) at the process boundary.
- `npm run checks` passes (lint, format, typecheck, 515 tests).