### PR TITLE
fix(claude-code): read array-shaped tool_result content

### DIFF
--- a/src/vendors/claude-code/transcript.test.ts
+++ b/src/vendors/claude-code/transcript.test.ts
@@ -15,6 +15,20 @@ describe('claude-code transcript', () => {
     })
   })
 
+  it('flattens an array-shaped tool_result into the action output (Claude Code ships text blocks, not only strings)', async () => {
+    const events = await readTranscript(
+      'test/fixtures/transcripts/tool-result-array-content.jsonl',
+    )
+
+    expect(events).toContainEqual({
+      kind: 'action',
+      tool: 'Bash',
+      input: { command: 'npm test' },
+      output: 'FAIL src/calc.test.ts\n1 failed',
+      toolUseId: 'tu_1',
+    })
+  })
+
   it('emits a prompt event for user text messages', async () => {
     const events = await readTranscript('test/fixtures/transcripts/basic.jsonl')
 

--- a/src/vendors/claude-code/transcript.ts
+++ b/src/vendors/claude-code/transcript.ts
@@ -3,6 +3,26 @@ import { z } from 'zod'
 import type { RawSessionEvent } from '../../types.js'
 import { readJsonl } from '../../utils/read-jsonl.js'
 
+/**
+ * A tool_result's `content` is a string in many entries but an array of
+ * content blocks in others (Claude Code persists the raw Anthropic
+ * message shape: text blocks, images, tool references). Normalize to a
+ * string by joining the text blocks; non-text blocks (images, tool
+ * references) carry nothing a text validator can read and are dropped.
+ * Without this the whole entry fails the schema and the tool's output is
+ * silently lost — a fail-open where the AI validator never sees a test
+ * run that happened to be reported as text blocks.
+ */
+const ToolResultContent = z.union([
+  z.string(),
+  z.array(z.unknown()).transform((blocks) =>
+    blocks
+      .map((block) => z.object({ text: z.string() }).safeParse(block))
+      .flatMap((parsed) => (parsed.success ? [parsed.data.text] : []))
+      .join('\n'),
+  ),
+])
+
 const ContentItemSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('tool_use'),
@@ -12,7 +32,7 @@ const ContentItemSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('tool_result'),
-    content: z.string(),
+    content: ToolResultContent,
     tool_use_id: z.string(),
   }),
   z.object({

--- a/test/fixtures/transcripts/tool-result-array-content.jsonl
+++ b/test/fixtures/transcripts/tool-result-array-content.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_1","name":"Bash","input":{"command":"npm test"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","content":[{"type":"text","text":"FAIL src/calc.test.ts"},{"type":"text","text":"1 failed"}]}]}}


### PR DESCRIPTION
Fixes #34.

Claude Code persists `tool_result.content` as a string **or** an array of content blocks, but the schema only accepted strings — so array-shaped results were dropped and the tool output `enforceTdd` reads from history vanished (fail-open).

Accept both shapes: join the text blocks, drop non-text (images / tool refs).
