### PR TITLE
fix(vendors): apply edits literally, not via $-interpreted replacement

### DIFF
--- a/src/vendors/apply-edit.test.ts
+++ b/src/vendors/apply-edit.test.ts
@@ -113,6 +113,44 @@ describe('applyEdit', () => {
     })
   })
 
+  it('inserts newString literally when it contains $ substitution patterns (faithful to the vendor literal edit)', async ({
+    makeFile,
+  }) => {
+    const filePath = await makeFile('before\nMARKER\nafter\n')
+
+    // The vendor (Claude Code) replaces oldString with newString verbatim.
+    // JS String.prototype.replace, given a string replacement, would treat
+    // $$, $&, $` and $' as special patterns and produce different bytes than
+    // what lands on disk — a fail-open where the engine evaluates content the
+    // agent never wrote. The reconstruction must match the real file exactly.
+    const newString = "x$$ $& $` $' y"
+    const result = await applyEdit({ filePath, oldString: 'MARKER', newString })
+
+    expect(result).toEqual({
+      ok: true,
+      content: `before\n${newString}\nafter\n`,
+    })
+  })
+
+  it('inserts newString literally under replaceAll when it contains $ patterns', async ({
+    makeFile,
+  }) => {
+    const filePath = await makeFile('one MARKER\ntwo MARKER\n')
+
+    const newString = 'cost $$5 for $&'
+    const result = await applyEdit({
+      filePath,
+      oldString: 'MARKER',
+      newString,
+      replaceAll: true,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      content: `one ${newString}\ntwo ${newString}\n`,
+    })
+  })
+
   it('fails closed when the file does not exist (no silent fallback to newString)', async () => {
     const result = await applyEdit({
       filePath: '/tmp/probity-apply-edit-does-not-exist.ts',

--- a/src/vendors/apply-edit.ts
+++ b/src/vendors/apply-edit.ts
@@ -50,9 +50,14 @@ export async function applyEdit(
       reason: `oldString matches ${occurrences} locations in ${filePath}; the Edit contract requires uniqueness unless replace_all is true.`,
     }
   }
+  // Insert newString via a replacer function so it lands verbatim: a
+  // string replacement would interpret $$, $&, $` and $' as special
+  // patterns, diverging from the vendor's literal edit and making the
+  // engine evaluate bytes the agent never wrote.
+  const replacer = () => newString
   const content = replaceAll
-    ? current.replaceAll(oldString, newString)
-    : current.replace(oldString, newString)
+    ? current.replaceAll(oldString, replacer)
+    : current.replace(oldString, replacer)
   return { ok: true, content }
 }
 


### PR DESCRIPTION
Fixes #36.

`applyEdit` rebuilt content with `String.replace`/`replaceAll` and a string replacement, so `$$`, `$&`, `` $` `` and `$'` in `newString` were interpreted as patterns instead of inserted literally — diverging from the vendor's literal edit, so the engine evaluated bytes the agent never wrote.

Insert `newString` via a replacer function (never subject to `$` interpretation).
