### PR TITLE
fix(rules): match dotfiles in files-scoped rules and sticky/global regexes anywhere

### DIFF
--- a/src/rules/utils/match-paths.test.ts
+++ b/src/rules/utils/match-paths.test.ts
@@ -38,6 +38,17 @@ describe('buildMatcher', () => {
     expect(matches('C:/proj/src/foo.ts')).toBe(true)
     expect(matches('C:/proj/lib/foo.ts')).toBe(false)
   })
+
+  it('matches dotfiles and dot-directories under a glob (fail-open guard)', () => {
+    expect(buildMatcher(['src/**'])('src/.eslintrc.js')).toBe(true)
+    expect(buildMatcher(['**/*.md'])('.github/CONTRIBUTING.md')).toBe(true)
+  })
+
+  it('applies dot-awareness to negations so a dotfile can be excluded', () => {
+    const matches = buildMatcher(['src/**', '!**/.env'])
+    expect(matches('src/app.ts')).toBe(true)
+    expect(matches('src/.env')).toBe(false)
+  })
 })
 
 describe('actionMatchesFilesScope', () => {

--- a/src/rules/utils/match-paths.ts
+++ b/src/rules/utils/match-paths.ts
@@ -8,6 +8,12 @@ import type { Action } from '../../types.js'
  * everything else is an include. An all-negations list matches nothing
  * positively, so `**` is supplied as the default include when only
  * negations are given.
+ *
+ * `dot: true` so `*` / `**` traverse dot-prefixed segments: without it a
+ * `files`-scoped rule silently skips dotfiles (`.env`, `.github/**`,
+ * `.eslintrc.js`) — a fail-open where a write that should be checked
+ * slips through. picomatch applies the option to the `ignore` matcher
+ * too, so negations stay dot-aware.
  */
 export function buildMatcher(patterns: string[]): (path: string) => boolean {
   if (patterns.length === 0) return () => false
@@ -15,7 +21,10 @@ export function buildMatcher(patterns: string[]): (path: string) => boolean {
   const ignore = patterns
     .filter((p) => p.startsWith('!'))
     .map((p) => p.slice(1))
-  const matcher = picomatch(includes.length ? includes : '**', { ignore })
+  const matcher = picomatch(includes.length ? includes : '**', {
+    dot: true,
+    ignore,
+  })
   return (path) => matcher(path)
 }
 

--- a/src/rules/utils/string-or-regex-matches.test.ts
+++ b/src/rules/utils/string-or-regex-matches.test.ts
@@ -12,4 +12,14 @@ describe('stringOrRegexMatches', () => {
     expect(stringOrRegexMatches('rm -rf /', /rm\s+-rf/)).toBe(true)
     expect(stringOrRegexMatches('git rm file', /rm\s+-rf/)).toBe(false)
   })
+
+  it('matches a sticky regex anywhere in the haystack (fail-open guard)', () => {
+    expect(stringOrRegexMatches('  forbidden', /forbidden/y)).toBe(true)
+  })
+
+  it('is not stateful across calls with a global regex', () => {
+    const re = /x/g
+    expect(stringOrRegexMatches('axb', re)).toBe(true)
+    expect(stringOrRegexMatches('axb', re)).toBe(true)
+  })
 })

--- a/src/rules/utils/string-or-regex-matches.ts
+++ b/src/rules/utils/string-or-regex-matches.ts
@@ -3,7 +3,11 @@ export function stringOrRegexMatches(
   needle: string | RegExp,
 ): boolean {
   if (typeof needle === 'string') return haystack.includes(needle)
-  // Use .search() rather than .test() because .test() on a /.../g regex
-  // mutates .lastIndex between invocations and would silently miss matches.
-  return haystack.search(needle) !== -1
+  // Test against a fresh regex with the stateful flags (g, y) stripped:
+  // a sticky /y regex anchors at lastIndex, so .search() / .test() would
+  // only look at offset 0 and silently miss a match further in — and a
+  // global /g regex would carry lastIndex across calls. We only care
+  // whether the pattern occurs anywhere, so neither flag should apply.
+  const stateless = new RegExp(needle.source, needle.flags.replace(/[gy]/g, ''))
+  return stateless.test(haystack)
 }


### PR DESCRIPTION
Addresses #30 — dotfiles + the sticky-regex minor. The codex multi-file `apply_patch` part is in #39.

- **Dotfiles (fail-open):** `match-paths` lacked `dot: true`, so `files`-scoped rules silently skipped `.env`, `.github/**`, etc. Added it (applies to negations too).
- **Sticky/global regex:** `stringOrRegexMatches` used `.search()`, which honors a `/y` regex's `lastIndex` and carries `/g` state across calls — silent misses. Strip `g`/`y` before testing.
