### PR TITLE
fix(codex): evaluate every file in a multi-file apply_patch

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -6,6 +6,7 @@ import { failClosedResponse, run, type RunResult, type Vendor } from './cli.js'
 import type { Config } from './config.js'
 import type { Agent, SessionEvent } from './types.js'
 import { enforceFilenameCasing } from './rules/enforce-filename-casing.js'
+import { forbidContentPattern } from './rules/forbid-content-pattern.js'
 import type { FileContent, Rule } from './rules/contract.js'
 import { parseAs } from './utils/parse-as.js'
 import type { ResponseShape as ClaudeCodeResponse } from './vendors/claude-code/adapter.js'
@@ -191,6 +192,74 @@ describe('cli', () => {
     const call = first.agentCalls?.[0]
     expect(call?.durationMs).toBeGreaterThanOrEqual(0)
     expect(call?.verdict).toEqual({ kind: 'pass', reason: 'ok', meta })
+  })
+
+  it('checks every file in a multi-file codex apply_patch (a later file cannot escape a path-scoped rule)', async () => {
+    const payload = JSON.stringify({
+      cwd: '/workspaces/probity',
+      tool_name: 'apply_patch',
+      tool_input: {
+        command:
+          '*** Begin Patch\n' +
+          '*** Add File: /workspaces/probity/src/ok.ts\n+fine\n' +
+          '*** Add File: /workspaces/probity/secret/leak.ts\n+FORBIDDEN\n' +
+          '*** End Patch\n',
+      },
+    })
+
+    const { response } = await setup({
+      vendor: 'codex',
+      payload,
+      config: {
+        rules: [
+          {
+            files: ['**/secret/**'],
+            rules: [
+              forbidContentPattern({ match: 'FORBIDDEN', reason: 'no leaks' }),
+            ],
+          },
+        ],
+        ai: stubAgent,
+      },
+    })
+    const parsed = parseAs<{ decision: string; reason: string }>(response)
+
+    expect(parsed.decision).toBe('block')
+    expect(parsed.reason).toMatch(/no leaks/)
+  })
+
+  it('scopes AI-call trace attribution to the action that made the call across a multi-file patch', async () => {
+    const agent: Agent = {
+      reason: () => Promise.resolve({ kind: 'pass', reason: 'ok' }),
+    }
+    const aiRule: Rule = async (_action, ctx) => {
+      await ctx?.agent?.reason('hi')
+      return { kind: 'pass' }
+    }
+    const payload = JSON.stringify({
+      cwd: '/workspaces/probity',
+      tool_name: 'apply_patch',
+      tool_input: {
+        command:
+          '*** Begin Patch\n' +
+          '*** Add File: src/f1.ts\n+a\n' +
+          '*** Add File: src/f2.ts\n+b\n' +
+          '*** End Patch\n',
+      },
+    })
+
+    const { trace } = await setup({
+      vendor: 'codex',
+      payload,
+      config: { rules: [aiRule], ai: agent },
+    })
+
+    const evaluated = trace.filter((t) => t.kind === 'rule-evaluated')
+    expect(evaluated).toHaveLength(2)
+    for (const entry of evaluated) {
+      if (entry.kind !== 'rule-evaluated') continue
+      expect(entry.agentCalls).toHaveLength(1)
+    }
   })
 
   it('returns a deny response when the adapter rejects the payload', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,17 +55,26 @@ async function dispatch(
   if (parsed.kind === 'invalid') {
     return respondParseFailed(entry, parsed.reason)
   }
-  const collector = createAgentCallCollector(agent)
-  const ctx = buildRuleContext(
-    parsed.rawHistory,
-    entry.toCanonical,
-    collector.agent,
-  )
-  const outcome = await evaluate(parsed.action, rules, ctx, collector.hooks)
-  return {
-    response: respond(entry, outcome.decision),
-    trace: collector.enrichTrace(outcome.trace),
+  // A payload can expand to several actions (e.g. a multi-file codex
+  // apply_patch). Evaluate each and short-circuit on the first block so
+  // no file in the batch escapes the rules. A fresh collector per action
+  // keeps AI-call attribution scoped to the action that made the call,
+  // rather than cross-crediting every action's trace entries.
+  const trace: TraceEntry[] = []
+  for (const action of parsed.actions) {
+    const collector = createAgentCallCollector(agent)
+    const ctx = buildRuleContext(
+      parsed.rawHistory,
+      entry.toCanonical,
+      collector.agent,
+    )
+    const outcome = await evaluate(action, rules, ctx, collector.hooks)
+    trace.push(...collector.enrichTrace(outcome.trace))
+    if (outcome.decision.kind === 'block') {
+      return { response: respond(entry, outcome.decision), trace }
+    }
   }
+  return { response: respond(entry, { kind: 'allow' }), trace }
 }
 
 /**
@@ -121,7 +130,7 @@ export function failClosedResponse(vendor: Vendor, error: unknown): string {
 type ParseResult =
   | {
       kind: 'ok'
-      action: Action
+      actions: readonly Action[]
       rawHistory: (() => Promise<RawSessionEvent[]>) | undefined
     }
   | { kind: 'invalid'; reason: string }
@@ -133,13 +142,13 @@ async function parsePayload(
   const parsed = tryParseJson(rawPayload)
   if (parsed.kind === 'fail') return invalid(parsed.reason)
 
-  const action = await entry.adapter.parseAction(parsed.value)
-  if (!action.ok) return invalid(action.reason)
+  const parsedAction = await entry.adapter.parseAction(parsed.value)
+  if (!parsedAction.ok) return invalid(parsedAction.reason)
 
   const sessionPath = entry.adapter.sessionPath?.(parsed.value)
   return {
     kind: 'ok',
-    action: action.action,
+    actions: parsedAction.actions,
     rawHistory: sessionPath
       ? () => entry.readTranscript(sessionPath)
       : undefined,

--- a/src/vendors/adapter.test.ts
+++ b/src/vendors/adapter.test.ts
@@ -5,7 +5,7 @@ import type { Action } from '../types.js'
 import { fromSchema, passthroughFor } from './adapter.js'
 
 describe('fromSchema', () => {
-  it('wraps a Zod schema into a parseAction returning {ok: true, action} for valid input', async () => {
+  it('wraps a Zod schema into a parseAction returning {ok: true, actions: [action]} for valid input', async () => {
     const schema = z
       .object({ kind: z.literal('command'), command: z.string() })
       .transform((d): Action => ({ kind: 'command', command: d.command }))
@@ -14,7 +14,26 @@ describe('fromSchema', () => {
 
     expect(await parse({ kind: 'command', command: 'echo hi' })).toEqual({
       ok: true,
-      action: { kind: 'command', command: 'echo hi' },
+      actions: [{ kind: 'command', command: 'echo hi' }],
+    })
+  })
+
+  it('normalizes a schema that yields multiple actions into the actions array', async () => {
+    const schema = z
+      .object({ kind: z.literal('multi') })
+      .transform((): Action[] => [
+        { kind: 'command', command: 'a' },
+        { kind: 'command', command: 'b' },
+      ])
+
+    const parse = fromSchema(schema)
+
+    expect(await parse({ kind: 'multi' })).toEqual({
+      ok: true,
+      actions: [
+        { kind: 'command', command: 'a' },
+        { kind: 'command', command: 'b' },
+      ],
     })
   })
 

--- a/src/vendors/adapter.ts
+++ b/src/vendors/adapter.ts
@@ -8,7 +8,7 @@ import type { Action, Decision } from '../types.js'
  * was malformed (`ok: false`) and the adapter explains why.
  */
 export type ParseActionResult =
-  | { ok: true; action: Action }
+  | { ok: true; actions: readonly Action[] }
   | { ok: false; reason: string }
 
 /**
@@ -19,12 +19,15 @@ export type ParseActionResult =
  * Edit transform that reads the current file to compute the full
  * post-edit content) work alongside fully-sync schemas.
  */
-export function fromSchema(
-  schema: z.ZodType<Action>,
+export function fromSchema<T extends Action | readonly Action[]>(
+  schema: z.ZodType<T>,
 ): (payload: unknown) => Promise<ParseActionResult> {
   return async (payload) => {
     const parsed = await schema.safeParseAsync(payload)
-    if (parsed.success) return { ok: true, action: parsed.data }
+    if (parsed.success) {
+      const data = parsed.data
+      return { ok: true, actions: Array.isArray(data) ? data : [data] }
+    }
     return {
       ok: false,
       reason: parsed.error.issues.flatMap(unwrapIssue).join('; '),

--- a/src/vendors/antigravity-cli/adapter.test.ts
+++ b/src/vendors/antigravity-cli/adapter.test.ts
@@ -14,7 +14,7 @@ describe('antigravity-cli adapter', () => {
     })
     expect(result).toEqual({
       ok: true,
-      action: { kind: 'command', command: 'npm test' },
+      actions: [{ kind: 'command', command: 'npm test' }],
     })
   })
 
@@ -26,7 +26,9 @@ describe('antigravity-cli adapter', () => {
     })
     expect(result).toEqual({
       ok: true,
-      action: { kind: 'write', path: '/work/src/note.txt', content: 'hello' },
+      actions: [
+        { kind: 'write', path: '/work/src/note.txt', content: 'hello' },
+      ],
     })
   })
 
@@ -46,11 +48,13 @@ describe('antigravity-cli adapter', () => {
     })
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: file.replace(/\\/g, '/'),
-        content: 'def answer():\n    return 2\n',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: file.replace(/\\/g, '/'),
+          content: 'def answer():\n    return 2\n',
+        },
+      ],
     })
   })
 
@@ -61,7 +65,7 @@ describe('antigravity-cli adapter', () => {
     })
     expect(result).toEqual({
       ok: true,
-      action: { kind: 'command', command: '' },
+      actions: [{ kind: 'command', command: '' }],
     })
   })
 

--- a/src/vendors/claude-code/adapter.test.ts
+++ b/src/vendors/claude-code/adapter.test.ts
@@ -47,11 +47,13 @@ describe('claude-code adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: '/workspaces/probity/src/UpperCase.ts',
-        content: 'x',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: '/workspaces/probity/src/UpperCase.ts',
+          content: 'x',
+        },
+      ],
     })
   })
 
@@ -105,11 +107,13 @@ describe('claude-code adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: filePath,
-        content: 'before\nREPLACED\nafter\n',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: filePath,
+          content: 'before\nREPLACED\nafter\n',
+        },
+      ],
     })
   })
 
@@ -153,11 +157,13 @@ describe('claude-code adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: filePath,
-        content: 'newName(); newName();\n',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: filePath,
+          content: 'newName(); newName();\n',
+        },
+      ],
     })
   })
 
@@ -290,11 +296,13 @@ describe('claude-code adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: '/workspaces/probity/analysis.ipynb',
-        content: 'print("hello")',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: '/workspaces/probity/analysis.ipynb',
+          content: 'print("hello")',
+        },
+      ],
     })
   })
 
@@ -311,11 +319,13 @@ describe('claude-code adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: '/workspaces/probity/analysis.ipynb',
-        content: '',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: '/workspaces/probity/analysis.ipynb',
+          content: '',
+        },
+      ],
     })
   })
 
@@ -347,5 +357,8 @@ async function setup(fixtureName: string) {
 
 function ok(result: ParseActionResult): Action {
   if (!result.ok) throw new Error(`expected ok, got: ${result.reason}`)
-  return result.action
+  if (result.actions.length !== 1) {
+    throw new Error(`expected exactly one action, got ${result.actions.length}`)
+  }
+  return result.actions[0]!
 }

--- a/src/vendors/codex/adapter.test.ts
+++ b/src/vendors/codex/adapter.test.ts
@@ -31,12 +31,14 @@ describe('codex adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: '/workspaces/probity/src/UpperCase.ts',
-        content:
-          '*** Begin Patch\n*** Add File: /workspaces/probity/src/UpperCase.ts\n+x\n*** End Patch\n',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: '/workspaces/probity/src/UpperCase.ts',
+          content:
+            '*** Add File: /workspaces/probity/src/UpperCase.ts\n+x\n*** End Patch\n',
+        },
+      ],
     })
   })
 
@@ -95,7 +97,7 @@ describe('codex adapter', () => {
     expect(action.kind).toBe('write')
     if (action.kind !== 'write') throw new Error('expected write')
     expect(action.path).toBe('/workspaces/probity/src/calculator.ts')
-    expect(action.content).toContain('*** Begin Patch')
+    expect(action.content).not.toContain('*** Begin Patch')
     expect(action.content).toContain('*** Add File:')
   })
 
@@ -115,6 +117,35 @@ describe('codex adapter', () => {
       kind: 'write',
       path: '/workspaces/probity/src/UpperCase.ts',
     })
+  })
+
+  it('emits one write action per file in a multi-file apply_patch (files 2..N must not be skipped)', async () => {
+    const result = await parseAction({
+      cwd: '/workspaces/probity',
+      tool_name: 'apply_patch',
+      tool_input: {
+        command:
+          '*** Begin Patch\n' +
+          '*** Add File: src/a.ts\n+a\n' +
+          '*** Add File: src/secret/b.ts\n+b\n' +
+          '*** End Patch\n',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.actions).toEqual([
+      {
+        kind: 'write',
+        path: '/workspaces/probity/src/a.ts',
+        content: '*** Add File: src/a.ts\n+a\n',
+      },
+      {
+        kind: 'write',
+        path: '/workspaces/probity/src/secret/b.ts',
+        content: '*** Add File: src/secret/b.ts\n+b\n*** End Patch\n',
+      },
+    ])
   })
 
   it('fails closed when an apply_patch payload omits cwd (vendors reliably emit it; absence is malformed)', async () => {
@@ -157,5 +188,8 @@ async function setup(fixtureName: string) {
 
 function ok(result: ParseActionResult): Action {
   if (!result.ok) throw new Error(`expected ok, got: ${result.reason}`)
-  return result.action
+  if (result.actions.length !== 1) {
+    throw new Error(`expected exactly one action, got ${result.actions.length}`)
+  }
+  return result.actions[0]!
 }

--- a/src/vendors/codex/adapter.ts
+++ b/src/vendors/codex/adapter.ts
@@ -11,7 +11,24 @@ import { posixAbsolute } from '../posix-absolute.js'
  */
 export type ResponseShape = { decision: string; reason: string }
 
-const PATCH_HEADER = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/m
+const PATCH_FILE_HEADER = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/gm
+
+/**
+ * Splits an apply_patch command into one section per file, keyed by the
+ * `*** Add/Update/Delete File:` headers. Each section runs from its
+ * header up to the next header (or the end of the patch), so a
+ * multi-file patch yields one write per file instead of collapsing to
+ * the first header — files 2..N would otherwise escape path-scoped
+ * rules entirely.
+ */
+function splitPatchFiles(command: string): { path: string; section: string }[] {
+  const headers = [...command.matchAll(PATCH_FILE_HEADER)]
+  return headers.map((header, i) => {
+    const start = header.index ?? 0
+    const next = headers[i + 1]?.index ?? command.length
+    return { path: header[1]!.trim(), section: command.slice(start, next) }
+  })
+}
 
 const bashSchema = z.object({
   tool_name: z.literal('Bash'),
@@ -36,20 +53,24 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
   bashSchema.transform(
     (d): Action => ({ kind: 'command', command: d.tool_input.command }),
   ),
-  applyPatchSchema.transform((d, ctx): Action => {
-    const path = PATCH_HEADER.exec(d.tool_input.command)?.[1]
-    if (!path) {
+  applyPatchSchema.transform((d, ctx): Action[] => {
+    const files = splitPatchFiles(d.tool_input.command)
+    if (files.length === 0) {
       ctx.addIssue({
         code: 'custom',
         message: 'apply_patch: no Add/Update/Delete File header',
       })
       return z.NEVER
     }
-    return {
+    // One Action per file so files 2..N are not skipped by path-scoped
+    // rules or per-file enforce-tdd. Each carries its own patch section
+    // as content (rather than the whole patch) so content rules see only
+    // that file's changes.
+    return files.map((file) => ({
       kind: 'write',
-      path: posixAbsolute(d.cwd, path),
-      content: d.tool_input.command,
-    }
+      path: posixAbsolute(d.cwd, file.path),
+      content: file.section,
+    }))
   }),
 ])
 

--- a/src/vendors/github-copilot-chat/adapter.test.ts
+++ b/src/vendors/github-copilot-chat/adapter.test.ts
@@ -47,11 +47,13 @@ describe('github-copilot-chat adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: '/workspaces/probity/src/UpperCase.ts',
-        content: 'x',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: '/workspaces/probity/src/UpperCase.ts',
+          content: 'x',
+        },
+      ],
     })
   })
 
@@ -127,11 +129,13 @@ describe('github-copilot-chat adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: filePath,
-        content: 'before\nREPLACED\nafter\n',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: filePath,
+          content: 'before\nREPLACED\nafter\n',
+        },
+      ],
     })
   })
 
@@ -247,5 +251,8 @@ async function setup(fixtureName: string) {
 
 function ok(result: ParseActionResult): Action {
   if (!result.ok) throw new Error(`expected ok, got: ${result.reason}`)
-  return result.action
+  if (result.actions.length !== 1) {
+    throw new Error(`expected exactly one action, got ${result.actions.length}`)
+  }
+  return result.actions[0]!
 }

--- a/src/vendors/github-copilot/adapter.test.ts
+++ b/src/vendors/github-copilot/adapter.test.ts
@@ -38,11 +38,13 @@ describe('github-copilot adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: '/workspaces/probity/src/UpperCase.ts',
-        content: 'x',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: '/workspaces/probity/src/UpperCase.ts',
+          content: 'x',
+        },
+      ],
     })
   })
 
@@ -116,11 +118,13 @@ describe('github-copilot adapter', () => {
 
     expect(result).toEqual({
       ok: true,
-      action: {
-        kind: 'write',
-        path: filePath,
-        content: 'before\nREPLACED\nafter\n',
-      },
+      actions: [
+        {
+          kind: 'write',
+          path: filePath,
+          content: 'before\nREPLACED\nafter\n',
+        },
+      ],
     })
   })
 
@@ -253,5 +257,8 @@ async function setup(fixtureName: string) {
 
 function ok(result: ParseActionResult): Action {
   if (!result.ok) throw new Error(`expected ok, got: ${result.reason}`)
-  return result.action
+  if (result.actions.length !== 1) {
+    throw new Error(`expected exactly one action, got ${result.actions.length}`)
+  }
+  return result.actions[0]!
 }


### PR DESCRIPTION
Addresses the codex multi-file `apply_patch` fail-open in #30 (the dotfiles + regex parts are in #38).

A codex `apply_patch` can touch several files, but only the first `*** … File:` header was read — files 2..N escaped path-scoped rules and per-file `enforceTdd`.

Let an adapter yield multiple actions: `ParseActionResult` carries `actions` (internal only), `fromSchema` wraps a single action so other adapters are unchanged, the cli evaluates each and blocks on the first violation, and codex splits the patch into one write per file.
