### PR TITLE
[codex] Fail closed on invalid rule results

### DIFF
--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -156,6 +156,21 @@ describe('engine', () => {
     })
   })
 
+  it('turns an invalid custom rule result into a block decision (fail-closed)', async () => {
+    const invalid: Rule = () =>
+      ({ kind: 'skip' }) as unknown as ReturnType<Rule>
+
+    const { decision } = await evaluate({ kind: 'command', command: 'x' }, [
+      invalid,
+    ])
+
+    expect(decision).toEqual({
+      kind: 'block',
+      reason:
+        'rule error: invalid rule result: expected kind "pass" or "violation"',
+    })
+  })
+
   it('records a rule-threw entry attributing the throwing rule', async () => {
     const crashing: Rule = () => {
       throw new Error('kaboom')

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,5 +1,11 @@
 import type { RuleEntry } from './config.js'
-import type { Action, Decision, Outcome, TraceEntry } from './types.js'
+import type {
+  Action,
+  Decision,
+  Outcome,
+  RuleResult,
+  TraceEntry,
+} from './types.js'
 import type { Rule, RuleContext } from './rules/contract.js'
 import { actionMatchesFilesScope } from './rules/utils/match-paths.js'
 
@@ -49,7 +55,12 @@ async function runRule(
   hooks?.onRuleStart?.(ruleName)
   const start = performance.now()
   try {
-    const result = await rule(action, ctx)
+    const result: unknown = await rule(action, ctx)
+    if (!isRuleResult(result)) {
+      throw new Error(
+        'invalid rule result: expected kind "pass" or "violation"',
+      )
+    }
     const durationMs = performance.now() - start
     const traceEntry: TraceEntry = {
       kind: 'rule-evaluated',
@@ -71,6 +82,16 @@ async function runRule(
   } finally {
     hooks?.onRuleEnd?.(ruleName)
   }
+}
+
+function isRuleResult(result: unknown): result is RuleResult {
+  if (!result || typeof result !== 'object') return false
+  const kind = (result as { kind?: unknown }).kind
+  if (kind === 'pass') return true
+  return (
+    kind === 'violation' &&
+    typeof (result as { reason?: unknown }).reason === 'string'
+  )
 }
 
 function resolveRules(entry: RuleEntry, action: Action): readonly Rule[] {


### PR DESCRIPTION
## Summary
- fail closed when a custom rule returns a result outside the `pass` / `violation` contract
- add a regression test for an invalid custom rule result

## Context
This addresses one remaining hardening item from #30: a custom rule returning a non-`violation` kind could silently allow an action. The dotfile scope and Codex multi-file `apply_patch` findings from #30 are already fixed on current `main` and are not bundled here.

## Validation
- Regression observed first: `npx vitest run src/engine.test.ts` failed before the engine change because the invalid rule result produced `{ kind: "allow" }`
- `npx vitest run src/engine.test.ts`
- `npm run checks`

## Policy notes
- Checked `CONTRIBUTING.md`, `package.json`, and `.github/workflows/ci.yml`; no CLA, DCO, signed-commit, or explicit AI disclosure requirement was observed
- No legal terms were accepted or certified

## AI assistance
Prepared with OpenAI Codex. I performed the live issue/PR overlap checks and local validation before opening this draft PR.