### PR TITLE
perf(rules): compact large edit prompts

### DIFF
--- a/docs/adr/0007-normalize-vendor-edits-to-write.md
+++ b/docs/adr/0007-normalize-vendor-edits-to-write.md
@@ -16,8 +16,12 @@ An edit-shape tool call becomes a canonical Write whose `content` is the full po
 
 A shared helper at the vendors root expresses these semantics so every edit-shape adapter borrows the same behavior rather than reinventing the failure modes per vendor.
 
+The canonical Write remains unchanged, but an adapter may also retain its validated Edit descriptor as non-serializable metadata keyed by the Action object's identity. AI rules can use that descriptor as a prompt projection without changing what deterministic or custom rules see in `Action.content`. `enforceTdd` uses this compact projection only for post-images of at least 64 KiB where it is at least four times smaller than the full content. Ordinary files keep the full before/after context.
+
 The projection reads disk, so `parseAction` becomes async (`Promise<ParseActionResult>`). The CLI's parse step becomes async in lockstep. I/O in the parsing path stays inside the adapter; adapters with no I/O pay nothing beyond an extra `await`.
 
 ## Consequences
 
 Rules see a uniform "this is what the file will look like after the write" regardless of whether the underlying tool call was an edit or a write. The cost of the file read sits at the boundary, not in the rule layer. Edit-shape tool calls that cannot be resolved become parse-time errors rather than misleading no-op Actions. Vendor projections that depend on filesystem state fit the same contract as projections that do not, and the CLI does not branch on whether a vendor is sync or async.
+
+The optional Edit metadata depends on the engine passing the same Action object from parsing to rule evaluation. Cloning or serializing an Action intentionally drops the metadata, in which case AI rules fall back to the canonical full-content path. The public Action shape and its JSON representation therefore remain backward compatible.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,10 +1,14 @@
 import { readFileSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, onTestFinished } from 'vitest'
 
 import { failClosedResponse, run, type RunResult, type Vendor } from './cli.js'
 import type { Config } from './config.js'
 import type { Agent, SessionEvent } from './types.js'
+import { enforceTdd } from './rules/enforce-tdd.js'
 import { enforceFilenameCasing } from './rules/enforce-filename-casing.js'
 import { forbidContentPattern } from './rules/forbid-content-pattern.js'
 import type { FileContent, Rule } from './rules/contract.js'
@@ -166,6 +170,49 @@ describe('cli', () => {
 
     expect(captured).toBeDefined()
     expect(captured?.kind).toBe('present')
+  })
+
+  it('preserves a large Edit delta through parsing and dispatch while other rules still receive the full post-image', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'probity-cli-edit-delta-'))
+    onTestFinished(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+    const filePath = path.join(dir, 'large.ts')
+    const unchanged = 'UNCHANGED_CLI_CONTEXT\n'.repeat(10_000)
+    await writeFile(filePath, `${unchanged}oldName()${unchanged}`)
+    let capturedContent = ''
+    let capturedPrompt = ''
+    const captureContent: Rule = (action) => {
+      if (action.kind === 'write') capturedContent = action.content
+      return Promise.resolve({ kind: 'pass' })
+    }
+    const agent: Agent = {
+      reason: (prompt) => {
+        capturedPrompt = prompt
+        return Promise.resolve({ kind: 'pass', reason: '' })
+      },
+    }
+    const payload = JSON.stringify({
+      cwd: dir,
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: filePath,
+        old_string: 'oldName()',
+        new_string: 'newName()',
+      },
+    })
+
+    await setup({
+      payload,
+      config: { rules: [captureContent, enforceTdd()], ai: agent },
+    })
+
+    expect(capturedContent).toContain('UNCHANGED_CLI_CONTEXT')
+    expect(capturedContent).toContain('newName()')
+    expect(capturedPrompt).toContain('oldName()')
+    expect(capturedPrompt).toContain('newName()')
+    expect(capturedPrompt).not.toContain('UNCHANGED_CLI_CONTEXT')
+    expect(capturedPrompt.length).toBeLessThan(10_000)
   })
 
   it('captures agent calls a rule makes onto the trace entry as agentCalls with the full Verdict embedded', async () => {

--- a/src/edit-delta.ts
+++ b/src/edit-delta.ts
@@ -1,0 +1,33 @@
+import type { Action } from './types.js'
+
+type WriteAction = Extract<Action, { kind: 'write' }>
+
+export type EditDelta = Readonly<{
+  oldString: string
+  newString: string
+  replaceAll: boolean
+  occurrences: number
+}>
+
+const editDeltas = new WeakMap<WriteAction, EditDelta>()
+
+/**
+ * Keeps the vendor's validated Edit operation alongside the canonical
+ * write without expanding Action's public, JSON-serializable shape.
+ */
+export function attachEditDelta(
+  action: WriteAction,
+  delta: EditDelta,
+): WriteAction {
+  editDeltas.set(action, { ...delta })
+  return action
+}
+
+export function getEditDelta(action: Action): EditDelta | undefined {
+  return action.kind === 'write' ? editDeltas.get(action) : undefined
+}
+
+/** Normalize vendor payloads and on-disk content in the same LF space. */
+export function normalizeEditText(text: string): string {
+  return text.replace(/\r\n/g, '\n')
+}

--- a/src/rules/enforce-tdd.test.ts
+++ b/src/rules/enforce-tdd.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 import { describe, it, expect, onTestFinished } from 'vitest'
 
+import { attachEditDelta } from '../edit-delta.js'
 import type { Action, RawSessionEvent, Verdict } from '../types.js'
 import { safeReadCapped } from '../utils/safe-read.js'
 import type { FileContent, RuleContext } from './contract.js'
@@ -70,6 +71,108 @@ describe('enforce-tdd', () => {
 
     expect(s.capturedPrompt).toContain('src/calc.ts')
     expect(s.capturedPrompt).toContain('export const add')
+  })
+
+  it('sends an Edit as its exact delta without reading or prompting the unchanged file body', async () => {
+    const unchanged = 'UNCHANGED_SURROUNDING_CONTEXT\n'.repeat(40_000)
+    let readFileCalls = 0
+    const s = setup({
+      readFile: () => {
+        readFileCalls++
+        return Promise.resolve({
+          kind: 'present',
+          content: `${unchanged}oldName()${unchanged}`,
+        })
+      },
+    })
+    const action = attachEditDelta(
+      writeAction('src/large.ts', `${unchanged}newName()${unchanged}`),
+      {
+        oldString: 'oldName()',
+        newString: 'newName()',
+        replaceAll: false,
+        occurrences: 1,
+      },
+    )
+
+    await s.rule(action, s.ctx)
+
+    expect(readFileCalls).toBe(0)
+    expect(s.capturedPrompt).toContain('src/large.ts')
+    expect(s.capturedPrompt).toContain('oldName()')
+    expect(s.capturedPrompt).toContain('newName()')
+    expect(s.capturedPrompt).toContain('replace one occurrence')
+    expect(s.capturedPrompt).not.toContain('UNCHANGED_SURROUNDING_CONTEXT')
+    expect(s.capturedPrompt.length).toBeLessThan(10_000)
+  })
+
+  it('keeps full context for a small Edit when delta projection would not materially improve latency', async () => {
+    let readFileCalls = 0
+    const before =
+      'function calculateInvoice() {\n  // DOMAIN_CONTEXT\n  return oldTotal\n}\n'
+    const after = before.replace('oldTotal', 'newTotal')
+    const s = setup({
+      readFile: () => {
+        readFileCalls++
+        return Promise.resolve({ kind: 'present', content: before })
+      },
+    })
+    const action = attachEditDelta(writeAction('src/invoice.ts', after), {
+      oldString: 'oldTotal',
+      newString: 'newTotal',
+      replaceAll: false,
+      occurrences: 1,
+    })
+
+    await s.rule(action, s.ctx)
+
+    expect(readFileCalls).toBe(1)
+    expect(s.capturedPrompt).toContain('DOMAIN_CONTEXT')
+    expect(s.capturedPrompt).toContain(after)
+  })
+
+  it('keeps full context when a large Edit descriptor is not four times smaller than the post-image', async () => {
+    const oldString = 'OLD_REGION'.repeat(7_000)
+    const newString = 'NEW_REGION'.repeat(7_000)
+    const before = `CONTEXT_REQUIRED\n${oldString}`
+    const after = `CONTEXT_REQUIRED\n${newString}`
+    let readFileCalls = 0
+    const s = setup({
+      readFile: () => {
+        readFileCalls++
+        return Promise.resolve({ kind: 'present', content: before })
+      },
+    })
+    const action = attachEditDelta(writeAction('src/large-region.ts', after), {
+      oldString,
+      newString,
+      replaceAll: false,
+      occurrences: 1,
+    })
+
+    await s.rule(action, s.ctx)
+
+    expect(readFileCalls).toBe(1)
+    expect(s.capturedPrompt).toContain('CONTEXT_REQUIRED')
+  })
+
+  it('describes the exact count for a large replace-all Edit', async () => {
+    const unchanged = 'large surrounding content\n'.repeat(10_000)
+    const s = setup()
+    const action = attachEditDelta(
+      writeAction('src/rename.ts', `${unchanged}newName newName newName`),
+      {
+        oldString: 'oldName',
+        newString: 'newName',
+        replaceAll: true,
+        occurrences: 3,
+      },
+    )
+
+    await s.rule(action, s.ctx)
+
+    expect(s.capturedPrompt).toContain('replace all 3 occurrences')
+    expect(s.capturedPrompt).not.toContain('large surrounding content')
   })
 
   it('includes recent session history in the AI prompt', async () => {
@@ -330,6 +433,35 @@ describe('enforce-tdd', () => {
     expect(s.agentCalled).toBe(false)
   })
 
+  it('still reads the full before-image for the fast-path on a large Edit', async () => {
+    const filler = '// unchanged\n'.repeat(8_000)
+    const before = `${filler}// INSERT_TEST\n`
+    const after = `${filler}it('new behavior', () => {})\n`
+    let readFileCalls = 0
+    const s = setup({
+      fastPath: true,
+      readFile: () => {
+        readFileCalls++
+        return Promise.resolve({ kind: 'present', content: before })
+      },
+    })
+    const action = attachEditDelta(writeAction('src/large.test.ts', after), {
+      oldString: '// INSERT_TEST',
+      newString: "it('new behavior', () => {})",
+      replaceAll: false,
+      occurrences: 1,
+    })
+
+    const result = await s.rule(action, s.ctx)
+
+    expect(result).toEqual({
+      kind: 'pass',
+      notes: [{ kind: 'fast-path' }],
+    })
+    expect(readFileCalls).toBe(1)
+    expect(s.agentCalled).toBe(false)
+  })
+
   it('preserves the validator verdict reason on the pass result', async () => {
     const s = setup({
       verdict: { kind: 'pass', reason: 'looks like a refactor' },
@@ -457,7 +589,7 @@ function setup(
 function writeAction(
   path = 'src/calc.ts',
   content = 'export const add = (a, b) => a + b',
-): Action {
+): Extract<Action, { kind: 'write' }> {
   return { kind: 'write', path, content }
 }
 

--- a/src/rules/enforce-tdd.ts
+++ b/src/rules/enforce-tdd.ts
@@ -1,3 +1,4 @@
+import { getEditDelta, type EditDelta } from '../edit-delta.js'
 import type { Action, RawSessionEvent, RuleResult } from '../types.js'
 import type { FileContent, RuleContext } from './contract.js'
 import { countNewTestNodes } from './matchers/count-new-test-nodes.js'
@@ -6,6 +7,8 @@ import { trimHistory, type HistoryWindow } from './trim-history.js'
 
 const DEFAULT_MAX_EVENTS = 10
 const DEFAULT_MAX_CONTENT_CHARS = 6000
+const MIN_POST_IMAGE_CHARS_FOR_EDIT_DELTA = 64 * 1024
+const MIN_EDIT_DELTA_REDUCTION_FACTOR = 4
 
 const PROCESS_INSTRUCTIONS = `## Role
 
@@ -179,15 +182,64 @@ function buildPrompt(
   historyBlock: string,
   before: FileContent,
   action: { path: string; content: string },
+  editProjection?: string,
 ): string {
   const sections = [PROCESS_INSTRUCTIONS, rules]
   if (historyBlock) sections.push(`## Recent session\n\n${historyBlock}`)
-  sections.push(`## Current file content\n\n${formatBefore(before)}`)
-  sections.push(
-    `## Pending action\n\nFile: ${action.path}\n\n${action.content}`,
-  )
+  if (editProjection) {
+    sections.push(
+      '## Current file content\n\n' +
+        '(unchanged surrounding content omitted; the Edit operation below was validated against the file on disk)',
+    )
+    sections.push(editProjection)
+  } else {
+    sections.push(`## Current file content\n\n${formatBefore(before)}`)
+    sections.push(
+      `## Pending action\n\nFile: ${action.path}\n\n${action.content}`,
+    )
+  }
   sections.push(RESPONSE_SPEC)
   return sections.join('\n\n')
+}
+
+function formatEditAction(path: string, delta: EditDelta): string {
+  const operation = delta.replaceAll
+    ? `replace all ${delta.occurrences} occurrences`
+    : 'replace one occurrence'
+  const descriptor = JSON.stringify({
+    file: path,
+    operation,
+    old_string: delta.oldString,
+    new_string: delta.newString,
+  })
+  return `## Pending action
+
+Validated Edit descriptor (JSON data):
+${descriptor}`
+}
+
+/**
+ * Project large, compact edits once. The length lower bound rejects giant
+ * descriptors without first allocating their JSON representation.
+ */
+function projectEditAction(
+  action: { path: string; content: string },
+  delta: EditDelta,
+): string | undefined {
+  if (action.content.length < MIN_POST_IMAGE_CHARS_FOR_EDIT_DELTA) return
+  const minimumProjectionChars =
+    action.path.length + delta.oldString.length + delta.newString.length
+  if (
+    minimumProjectionChars * MIN_EDIT_DELTA_REDUCTION_FACTOR >
+    action.content.length
+  ) {
+    return
+  }
+  const projection = formatEditAction(action.path, delta)
+  return projection.length * MIN_EDIT_DELTA_REDUCTION_FACTOR <=
+    action.content.length
+    ? projection
+    : undefined
 }
 
 function formatBefore(before: FileContent): string {
@@ -270,13 +322,18 @@ export function enforceTdd(
     ctx?: RuleContext,
   ): Promise<RuleResult> {
     if (action.kind !== 'write') return { kind: 'pass' }
-    const before: FileContent = (await ctx?.readFile?.(action.path)) ?? {
-      kind: 'unknown',
-    }
+    const attachedEditDelta = getEditDelta(action)
+    const editProjection = attachedEditDelta
+      ? projectEditAction(action, attachedEditDelta)
+      : undefined
+    const before: FileContent =
+      editProjection && !fastPath
+        ? { kind: 'unknown' }
+        : ((await ctx?.readFile?.(action.path)) ?? { kind: 'unknown' })
     if (fastPath && isSingleNewTest(action, before)) {
       return { kind: 'pass', notes: [{ kind: 'fast-path' }] }
     }
-    return validateWithAi(action, ctx, before, rules, window)
+    return validateWithAi(action, ctx, before, rules, window, editProjection)
   }
 }
 
@@ -302,6 +359,7 @@ async function validateWithAi(
   before: FileContent,
   rules: string,
   window: HistoryWindow,
+  editProjection?: string,
 ): Promise<RuleResult> {
   if (!ctx?.agent) {
     return {
@@ -313,7 +371,13 @@ async function validateWithAi(
   const events = (await ctx.rawHistory?.()) ?? []
   const windowed = trimHistory(events, window)
   const historyBlock = windowed.map(formatEvent).join('\n')
-  const prompt = buildPrompt(rules, historyBlock, before, action)
+  const prompt = buildPrompt(
+    rules,
+    historyBlock,
+    before,
+    action,
+    editProjection,
+  )
   const verdict = await ctx.agent.reason(prompt)
   if (verdict.kind === 'violation') {
     return { kind: 'violation', reason: verdict.reason }

--- a/src/vendors/antigravity-cli/adapter.test.ts
+++ b/src/vendors/antigravity-cli/adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { createSandbox } from '../../../test/helpers/sandbox.js'
+import { getEditDelta } from '../../edit-delta.js'
 import type { Decision } from '../../types.js'
 import { parseAction, sessionPath, toResponse } from './adapter.js'
 
@@ -55,6 +56,12 @@ describe('antigravity-cli adapter', () => {
           content: 'def answer():\n    return 2\n',
         },
       ],
+    })
+    expect(result.ok && getEditDelta(result.actions[0]!)).toEqual({
+      oldString: '    return 1',
+      newString: '    return 2',
+      replaceAll: false,
+      occurrences: 1,
     })
   })
 

--- a/src/vendors/antigravity-cli/adapter.ts
+++ b/src/vendors/antigravity-cli/adapter.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { attachEditDelta } from '../../edit-delta.js'
 import type { Action, Decision } from '../../types.js'
 import { fromSchema, passthroughFor } from '../adapter.js'
 import { applyEdit } from '../apply-edit.js'
@@ -49,7 +50,10 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
       ctx.addIssue({ code: 'custom', message: result.reason })
       return z.NEVER
     }
-    return { kind: 'write', path, content: result.content }
+    return attachEditDelta(
+      { kind: 'write', path, content: result.content },
+      result.delta,
+    )
   }),
 ])
 

--- a/src/vendors/apply-edit.test.ts
+++ b/src/vendors/apply-edit.test.ts
@@ -26,7 +26,16 @@ describe('applyEdit', () => {
       newString: 'REPLACED',
     })
 
-    expect(result).toEqual({ ok: true, content: 'before\nREPLACED\nafter\n' })
+    expect(result).toEqual({
+      ok: true,
+      content: 'before\nREPLACED\nafter\n',
+      delta: {
+        oldString: 'MARKER',
+        newString: 'REPLACED',
+        replaceAll: false,
+        occurrences: 1,
+      },
+    })
   })
 
   it('fails closed when oldString does not appear in the file (no silent no-op)', async ({
@@ -76,6 +85,12 @@ describe('applyEdit', () => {
     expect(result).toEqual({
       ok: true,
       content: 'one REPLACED\ntwo REPLACED\nthree REPLACED\n',
+      delta: {
+        oldString: 'MARKER',
+        newString: 'REPLACED',
+        replaceAll: true,
+        occurrences: 3,
+      },
     })
   })
 
@@ -93,6 +108,12 @@ describe('applyEdit', () => {
     expect(result).toEqual({
       ok: true,
       content: 'first\nREPLACED\nlast\n',
+      delta: {
+        oldString: 'first\nMARKER\nlast',
+        newString: 'first\nREPLACED\nlast',
+        replaceAll: false,
+        occurrences: 1,
+      },
     })
   })
 
@@ -110,6 +131,12 @@ describe('applyEdit', () => {
     expect(result).toEqual({
       ok: true,
       content: 'first\nREPLACED\nlast\n',
+      delta: {
+        oldString: 'first\nMARKER\nlast',
+        newString: 'first\nREPLACED\nlast',
+        replaceAll: false,
+        occurrences: 1,
+      },
     })
   })
 
@@ -129,6 +156,12 @@ describe('applyEdit', () => {
     expect(result).toEqual({
       ok: true,
       content: `before\n${newString}\nafter\n`,
+      delta: {
+        oldString: 'MARKER',
+        newString,
+        replaceAll: false,
+        occurrences: 1,
+      },
     })
   })
 
@@ -148,6 +181,12 @@ describe('applyEdit', () => {
     expect(result).toEqual({
       ok: true,
       content: `one ${newString}\ntwo ${newString}\n`,
+      delta: {
+        oldString: 'MARKER',
+        newString,
+        replaceAll: true,
+        occurrences: 2,
+      },
     })
   })
 

--- a/src/vendors/apply-edit.ts
+++ b/src/vendors/apply-edit.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises'
 
+import { normalizeEditText, type EditDelta } from '../edit-delta.js'
+
 export type ApplyEditOptions = {
   filePath: string
   oldString: string
@@ -8,7 +10,8 @@ export type ApplyEditOptions = {
 }
 
 export type ApplyEditResult =
-  { ok: true; content: string } | { ok: false; reason: string }
+  | { ok: true; content: string; delta: EditDelta }
+  | { ok: false; reason: string }
 
 /**
  * Reads the file at `filePath` and applies the substitution requested
@@ -33,9 +36,9 @@ export async function applyEdit(
       reason: `could not read ${filePath}: ${message}`,
     }
   }
-  const current = toLF(raw)
-  const oldString = toLF(options.oldString)
-  const newString = toLF(options.newString)
+  const current = normalizeEditText(raw)
+  const oldString = normalizeEditText(options.oldString)
+  const newString = normalizeEditText(options.newString)
   const occurrences = countOccurrences(current, oldString)
   if (occurrences === 0) {
     return {
@@ -57,15 +60,11 @@ export async function applyEdit(
   const content = replaceAll
     ? current.replaceAll(oldString, replacer)
     : current.replace(oldString, replacer)
-  return { ok: true, content }
-}
-
-/**
- * Files persisted on Windows commonly use CRLF while agents normalize
- * the JSON payload to LF; matching in LF-space avoids spurious misses.
- */
-function toLF(s: string): string {
-  return s.replace(/\r\n/g, '\n')
+  return {
+    ok: true,
+    content,
+    delta: { oldString, newString, replaceAll, occurrences },
+  }
 }
 
 function countOccurrences(haystack: string, needle: string): number {

--- a/src/vendors/claude-code/adapter.test.ts
+++ b/src/vendors/claude-code/adapter.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { describe, expect, test as baseTest } from 'vitest'
 
 import { makeSandboxDir } from '../../../test/helpers/sandbox.js'
+import { getEditDelta } from '../../edit-delta.js'
 import type { Action } from '../../types.js'
 import { parseAs } from '../../utils/parse-as.js'
 import type { ParseActionResult } from '../adapter.js'
@@ -115,6 +116,36 @@ describe('claude-code adapter', () => {
         },
       ],
     })
+  })
+
+  it('retains the exact Edit operation as non-serialized rule metadata', async ({
+    dir,
+    makeFile,
+  }) => {
+    const filePath = await makeFile('before\r\nMARKER\r\nafter\r\n')
+
+    const result = await parseAction({
+      cwd: dir,
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: filePath,
+        old_string: 'before\r\nMARKER\r\nafter',
+        new_string: 'before\r\nREPLACED\r\nafter',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const action = result.actions[0]
+    expect(action).toBeDefined()
+    if (!action) return
+    expect(getEditDelta(action)).toEqual({
+      oldString: 'before\nMARKER\nafter',
+      newString: 'before\nREPLACED\nafter',
+      replaceAll: false,
+      occurrences: 1,
+    })
+    expect(JSON.stringify(action)).not.toContain('oldString')
   })
 
   it('Edit succeeds when the on-disk file is CRLF and the agent sent old_string as LF (Windows-typical)', async ({

--- a/src/vendors/claude-code/adapter.ts
+++ b/src/vendors/claude-code/adapter.ts
@@ -1,6 +1,7 @@
 import type { PreToolUseHookSpecificOutput } from '@anthropic-ai/claude-agent-sdk'
 import { z } from 'zod'
 
+import { attachEditDelta } from '../../edit-delta.js'
 import type { Action, Decision } from '../../types.js'
 import { fromSchema, passthroughFor } from '../adapter.js'
 import { applyEdit } from '../apply-edit.js'
@@ -89,7 +90,10 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
       ctx.addIssue({ code: 'custom', message: result.reason })
       return z.NEVER
     }
-    return { kind: 'write', path, content: result.content }
+    return attachEditDelta(
+      { kind: 'write', path, content: result.content },
+      result.delta,
+    )
   }),
   writeSchema.transform((d): Action => ({
     kind: 'write',

--- a/src/vendors/github-copilot-chat/adapter.test.ts
+++ b/src/vendors/github-copilot-chat/adapter.test.ts
@@ -6,6 +6,7 @@ import type { PreToolUseHookSpecificOutput } from '@anthropic-ai/claude-agent-sd
 import { describe, expect, test as baseTest } from 'vitest'
 
 import { makeSandboxDir } from '../../../test/helpers/sandbox.js'
+import { getEditDelta } from '../../edit-delta.js'
 import type { Action } from '../../types.js'
 import { parseAs } from '../../utils/parse-as.js'
 import type { ParseActionResult } from '../adapter.js'
@@ -136,6 +137,12 @@ describe('github-copilot-chat adapter', () => {
           content: 'before\nREPLACED\nafter\n',
         },
       ],
+    })
+    expect(result.ok && getEditDelta(result.actions[0]!)).toEqual({
+      oldString: 'MARKER',
+      newString: 'REPLACED',
+      replaceAll: false,
+      occurrences: 1,
     })
   })
 

--- a/src/vendors/github-copilot-chat/adapter.ts
+++ b/src/vendors/github-copilot-chat/adapter.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { attachEditDelta } from '../../edit-delta.js'
 import type { Action, Decision } from '../../types.js'
 import { fromSchema, passthroughFor } from '../adapter.js'
 import { applyEdit } from '../apply-edit.js'
@@ -68,7 +69,10 @@ const writeToolsSchema = z.discriminatedUnion('tool_name', [
       ctx.addIssue({ code: 'custom', message: result.reason })
       return z.NEVER
     }
-    return { kind: 'write', path: filePath, content: result.content }
+    return attachEditDelta(
+      { kind: 'write', path: filePath, content: result.content },
+      result.delta,
+    )
   }),
 ])
 

--- a/src/vendors/github-copilot/adapter.test.ts
+++ b/src/vendors/github-copilot/adapter.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { describe, expect, test as baseTest } from 'vitest'
 
 import { makeSandboxDir } from '../../../test/helpers/sandbox.js'
+import { getEditDelta } from '../../edit-delta.js'
 import type { Action } from '../../types.js'
 import { parseAs } from '../../utils/parse-as.js'
 import type { ParseActionResult } from '../adapter.js'
@@ -125,6 +126,12 @@ describe('github-copilot adapter', () => {
           content: 'before\nREPLACED\nafter\n',
         },
       ],
+    })
+    expect(result.ok && getEditDelta(result.actions[0]!)).toEqual({
+      oldString: 'MARKER',
+      newString: 'REPLACED',
+      replaceAll: false,
+      occurrences: 1,
     })
   })
 

--- a/src/vendors/github-copilot/adapter.ts
+++ b/src/vendors/github-copilot/adapter.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { z } from 'zod'
 
+import { attachEditDelta } from '../../edit-delta.js'
 import type { Action, Decision } from '../../types.js'
 import { JsonString } from '../../utils/json-string.js'
 import { fromSchema, passthroughFor } from '../adapter.js'
@@ -74,7 +75,10 @@ const writeToolsSchema = z.discriminatedUnion('toolName', [
       ctx.addIssue({ code: 'custom', message: result.reason })
       return z.NEVER
     }
-    return { kind: 'write', path: filePath, content: result.content }
+    return attachEditDelta(
+      { kind: 'write', path: filePath, content: result.content },
+      result.delta,
+    )
   }),
 ])
 


### PR DESCRIPTION
## What

This is an initial attempt at reducing the input that `enforceTdd` sends for a localized Edit in a large file.

Adapters still produce the same canonical Write with the full post-edit content. They also retain the already validated Edit descriptor as non-serialized metadata. For post-images of at least 64 KiB, `enforceTdd` uses that descriptor only when it is at least four times smaller than the full content. Smaller or broad edits keep the existing full-context path.

Would this projection and fallback threshold fit the rule's intended trade-off between context and validator latency?

## Why

A one-line Edit currently makes the validator receive the complete post-image. In a local 50 MiB case, that produced a 52,435,726-character prompt even though the actual replacement was small.

The projected prompt was 7,191 characters. Prompt construction dropped from 35.03 ms to 0.26 ms, while the canonical full post-image remained available to every other rule.

## Compatibility

- The public `Action` shape and JSON representation are unchanged.
- Existing content and custom rules still receive the full post-image.
- Small files, broad edits, and `fastPath` retain the full before/after behavior.
- Claude Code, GitHub Copilot CLI, GitHub Copilot Chat, and Antigravity use the same projection metadata.

## Verification

- `npm run checks`
- 58 test suites passed
- 544 tests passed, with 26 existing skips
- Local 1 MiB, 10 MiB, and 50 MiB Edit benchmarks using the CLI's 1 MiB read cap
- A 20 MiB full-fallback benchmark to check that rejected descriptors do not add CPU or memory overhead
