### PR TITLE
perf(rules): split stable TDD system prompt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ See [Rules](rules.md) for the built-in catalog.
 
 ## The `ai` override
 
-Probity's default AI validator pairs with the agent selected by `--agent` (e.g. the Claude Agent SDK for `claude-code`) and piggybacks on the user's logged-in session. To use a different model or provider, set `ai` on the config; the value must implement `{ reason: (prompt: string) => Promise<Verdict> }`.
+Probity's default AI validator pairs with the agent selected by `--agent` (e.g. the Claude Agent SDK for `claude-code`) and piggybacks on the user's logged-in session. To use a different model or provider, set `ai` on the config; the value must implement `{ reason: (prompt: string) => Promise<Verdict> }`. Providers that support a distinct system prompt may also implement `reasonWithSystem({ system, prompt })`; Probity falls back to `reason` when it is absent.
 
 The host coding agent itself is selected by the `--agent` CLI flag, not by the config — that keeps the same config portable across vendors.
 

--- a/src/agent-call-collector.test.ts
+++ b/src/agent-call-collector.test.ts
@@ -54,6 +54,57 @@ describe('createAgentCallCollector', () => {
 
     expect(collector.enrichTrace(trace)).toEqual(trace)
   })
+
+  it('preserves and records the optional system-aware agent capability', async () => {
+    const verdict: Verdict = { kind: 'pass', reason: 'system-aware' }
+    const received: { system: string; prompt: string }[] = []
+    const collector = createAgentCallCollector({
+      reason: () => Promise.resolve(verdict),
+      reasonWithSystem: (input) => {
+        received.push(input)
+        return Promise.resolve(verdict)
+      },
+    })
+
+    collector.hooks.onRuleStart?.('enforceTdd')
+    const returned = await collector.agent.reasonWithSystem?.({
+      system: 'stable',
+      prompt: 'dynamic',
+    })
+    collector.hooks.onRuleEnd?.('enforceTdd')
+
+    expect(received).toEqual([{ system: 'stable', prompt: 'dynamic' }])
+    expect(returned).toEqual(verdict)
+    const [entry] = collector.enrichTrace([ruleEvaluated('enforceTdd')])
+    expect(entry?.kind === 'rule-evaluated' && entry.agentCalls).toHaveLength(1)
+  })
+
+  it('does not invent a system-aware capability for a reason-only agent', () => {
+    const { collector } = setup()
+
+    expect(collector.agent.reasonWithSystem).toBeUndefined()
+  })
+
+  it('preserves the receiver for system-aware agent methods', async () => {
+    const inner = {
+      prefix: 'bound',
+      reason: () => Promise.resolve({ kind: 'pass' as const, reason: '' }),
+      reasonWithSystem() {
+        return Promise.resolve({
+          kind: 'pass' as const,
+          reason: this.prefix,
+        })
+      },
+    }
+    const collector = createAgentCallCollector(inner)
+
+    const verdict = await collector.agent.reasonWithSystem?.({
+      system: 'stable',
+      prompt: 'dynamic',
+    })
+
+    expect(verdict?.reason).toBe('bound')
+  })
 })
 
 function setup(options: { verdict?: Verdict } = {}) {

--- a/src/agent-call-collector.ts
+++ b/src/agent-call-collector.ts
@@ -2,9 +2,9 @@ import type { Agent, AgentCall, TraceEntry } from './types.js'
 import type { EvaluateHooks } from './engine.js'
 
 /**
- * Captures AI validator calls for the operator trace. Rules stay clean:
- * they call `ctx.agent.reason(prompt)`; attribution flows through this
- * collector without rule cooperation. Calls made outside any rule's
+ * Captures AI validator calls for the operator trace. Attribution flows
+ * through this collector without rule cooperation, including calls that use
+ * the optional system-prompt capability. Calls made outside any rule's
  * lifecycle are silently dropped.
  */
 export type AgentCallCollector = {
@@ -30,13 +30,18 @@ function withCallTiming(
   inner: Agent,
   onCall: (call: AgentCall) => void,
 ): Agent {
+  const timed = async (run: () => ReturnType<Agent['reason']>) => {
+    const start = performance.now()
+    const verdict = await run()
+    onCall({ durationMs: performance.now() - start, verdict })
+    return verdict
+  }
+  const reasonWithSystem = inner.reasonWithSystem?.bind(inner)
   return {
-    reason: async (prompt) => {
-      const start = performance.now()
-      const verdict = await inner.reason(prompt)
-      onCall({ durationMs: performance.now() - start, verdict })
-      return verdict
-    },
+    reason: (prompt) => timed(() => inner.reason(prompt)),
+    ...(reasonWithSystem && {
+      reasonWithSystem: (input) => timed(() => reasonWithSystem(input)),
+    }),
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   Agent,
   Decision,
   RawSessionEvent,
+  SystemPromptInput,
   Verdict,
 } from './types.js'
 export * from './rules/index.js'

--- a/src/rules/enforce-tdd.test.ts
+++ b/src/rules/enforce-tdd.test.ts
@@ -158,6 +158,77 @@ describe('enforce-tdd', () => {
     expect(s.capturedPrompt).toMatch(/three inputs|chronological/i)
   })
 
+  it('sends stable instructions separately from per-write evidence when the agent supports it', async () => {
+    const calls: { system: string; prompt: string }[] = []
+    const rule = enforceTdd({ instructions: 'CUSTOM_STABLE_TDD_RULE' })
+    const ctx: RuleContext = {
+      agent: {
+        reason: () => {
+          throw new Error('combined fallback should not be called')
+        },
+        reasonWithSystem: (input) => {
+          calls.push(input)
+          return Promise.resolve({ kind: 'pass', reason: '' })
+        },
+      },
+      rawHistory: () =>
+        Promise.resolve([{ kind: 'prompt', text: 'DYNAMIC_USER_EVIDENCE' }]),
+      readFile: () =>
+        Promise.resolve({ kind: 'present', content: 'DYNAMIC_BEFORE' }),
+    }
+
+    await rule(writeAction('src/first.ts', 'DYNAMIC_FIRST_WRITE'), ctx)
+    await rule(writeAction('src/second.ts', 'DYNAMIC_SECOND_WRITE'), ctx)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.system).toBe(calls[1]?.system)
+    expect(calls[0]?.system).toContain('CUSTOM_STABLE_TDD_RULE')
+    expect(calls[0]?.system).toMatch(/TDD validator/i)
+    expect(calls[0]?.system).not.toContain('DYNAMIC_USER_EVIDENCE')
+    expect(calls[0]?.prompt).toContain('DYNAMIC_USER_EVIDENCE')
+    expect(calls[0]?.prompt).toContain('DYNAMIC_BEFORE')
+    expect(calls[0]?.prompt).toContain('DYNAMIC_FIRST_WRITE')
+    expect(calls[0]?.prompt).toMatch(/Response format/i)
+    expect(calls[1]?.prompt).toContain('DYNAMIC_SECOND_WRITE')
+  })
+
+  it('keeps the legacy combined prompt for reason-only agents', async () => {
+    let combined = ''
+    let separated: { system: string; prompt: string } | undefined
+    const sharedContext = {
+      rawHistory: () =>
+        Promise.resolve([{ kind: 'prompt' as const, text: 'USER_EVIDENCE' }]),
+      readFile: () =>
+        Promise.resolve({ kind: 'present' as const, content: 'BEFORE' }),
+    }
+    const action = writeAction('src/example.ts', 'AFTER')
+    const rule = enforceTdd({ instructions: 'CUSTOM_TDD_RULE' })
+
+    await rule(action, {
+      ...sharedContext,
+      agent: {
+        reason: (prompt) => {
+          combined = prompt
+          return Promise.resolve({ kind: 'pass', reason: '' })
+        },
+      },
+    })
+    await rule(action, {
+      ...sharedContext,
+      agent: {
+        reason: () => {
+          throw new Error('combined fallback should not be called')
+        },
+        reasonWithSystem: (input) => {
+          separated = input
+          return Promise.resolve({ kind: 'pass', reason: '' })
+        },
+      },
+    })
+
+    expect(combined).toBe(`${separated?.system}\n\n${separated?.prompt}`)
+  })
+
   it('uses ctx.readFile to source the current file content for the prompt', async () => {
     const s = setup({
       readFile: () =>

--- a/src/rules/enforce-tdd.ts
+++ b/src/rules/enforce-tdd.ts
@@ -179,15 +179,18 @@ function buildPrompt(
   historyBlock: string,
   before: FileContent,
   action: { path: string; content: string },
-): string {
-  const sections = [PROCESS_INSTRUCTIONS, rules]
+): { system: string; prompt: string } {
+  const sections = []
   if (historyBlock) sections.push(`## Recent session\n\n${historyBlock}`)
   sections.push(`## Current file content\n\n${formatBefore(before)}`)
   sections.push(
     `## Pending action\n\nFile: ${action.path}\n\n${action.content}`,
   )
   sections.push(RESPONSE_SPEC)
-  return sections.join('\n\n')
+  return {
+    system: [PROCESS_INSTRUCTIONS, rules].join('\n\n'),
+    prompt: sections.join('\n\n'),
+  }
 }
 
 function formatBefore(before: FileContent): string {
@@ -205,8 +208,7 @@ function formatBefore(before: FileContent): string {
  * Blocks a write unless the session's recent history shows a failing
  * test that the pending implementation would address, and the write
  * is the minimum implementation needed to make that test pass. Uses
- * an AI validator (via `ctx.agent.reason`) to judge the pending action
- * against the transcript.
+ * an AI validator to judge the pending action against the transcript.
  *
  * Applies to: write actions.
  * Supported agents: Claude Code, Codex, GitHub Copilot.
@@ -314,7 +316,9 @@ async function validateWithAi(
   const windowed = trimHistory(events, window)
   const historyBlock = windowed.map(formatEvent).join('\n')
   const prompt = buildPrompt(rules, historyBlock, before, action)
-  const verdict = await ctx.agent.reason(prompt)
+  const verdict = ctx.agent.reasonWithSystem
+    ? await ctx.agent.reasonWithSystem(prompt)
+    : await ctx.agent.reason(`${prompt.system}\n\n${prompt.prompt}`)
   if (verdict.kind === 'violation') {
     return { kind: 'violation', reason: verdict.reason }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,13 +114,22 @@ export type Verdict = {
 }
 
 /**
- * The minimal AI-validator contract. Rules that need LLM judgment reach
- * for `ctx.agent.reason(prompt)`; agents implement this one method and
- * are swappable without touching rule code.
+ * The minimal AI-validator contract. Implementing `reason` is sufficient;
+ * providers can additionally expose a distinct system-prompt channel.
  */
 export type Agent = {
   reason: (prompt: string) => Promise<Verdict>
+  /**
+   * Sends stable instructions separately when the provider exposes a system
+   * prompt. Callers fall back to `reason` when this capability is absent.
+   */
+  reasonWithSystem?: (input: SystemPromptInput) => Promise<Verdict>
 }
+
+export type SystemPromptInput = Readonly<{
+  system: string
+  prompt: string
+}>
 
 /**
  * A vendor-shaped event from the agent's recent session — what the

--- a/src/vendors/claude-code/agent.test.ts
+++ b/src/vendors/claude-code/agent.test.ts
@@ -89,6 +89,31 @@ describe('claudeCode', () => {
     expect(capture.last?.options?.persistSession).toBe(false)
   })
 
+  it('passes stable instructions through the cacheable system prompt boundary', async () => {
+    const capture = captureQuery()
+    const client = claudeCode({ queryFn: capture.fn })
+
+    await client.reasonWithSystem?.({
+      system: 'STABLE_TDD_INSTRUCTIONS',
+      prompt: 'DYNAMIC_WRITE_EVIDENCE',
+    })
+
+    expect(capture.last?.prompt).toBe('DYNAMIC_WRITE_EVIDENCE')
+    expect(capture.last?.options?.systemPrompt).toEqual([
+      'STABLE_TDD_INSTRUCTIONS',
+      '__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__',
+    ])
+  })
+
+  it('leaves the system prompt unset for existing direct reason calls', async () => {
+    const capture = captureQuery()
+    const client = claudeCode({ queryFn: capture.fn })
+
+    await client.reason('combined prompt')
+
+    expect(capture.last?.options?.systemPrompt).toBeUndefined()
+  })
+
   it('parses a verdict from a fenced code block', async () => {
     const client = claudeCode({
       queryFn: fakeQuery({

--- a/src/vendors/claude-code/agent.ts
+++ b/src/vendors/claude-code/agent.ts
@@ -5,18 +5,29 @@ import { toVerdict } from '../to-verdict.js'
 
 type ClaudeMessage = { type: string; [k: string]: unknown }
 
+// Keep the SDK runtime lazy-loaded. This mirrors its public marker value
+// without adding an eager import to every hook invocation.
+const SYSTEM_PROMPT_DYNAMIC_BOUNDARY: typeof import('@anthropic-ai/claude-agent-sdk').SYSTEM_PROMPT_DYNAMIC_BOUNDARY =
+  '__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__'
+
 export type QueryFn = (args: {
   prompt: string
   options?: ClaudeQueryOptions
 }) => AsyncIterable<ClaudeMessage>
 
 export function claudeCode(deps: { queryFn?: QueryFn } = {}): Agent {
+  const reason = (
+    prompt: string,
+    systemPrompt?: ClaudeQueryOptions['systemPrompt'],
+  ) =>
+    toVerdict(async () => {
+      const queryFn = deps.queryFn ?? (await loadDefaultQueryFn())
+      return getResult(queryFn, prompt, systemPrompt)
+    })
   return {
-    reason: (prompt) =>
-      toVerdict(async () => {
-        const queryFn = deps.queryFn ?? (await loadDefaultQueryFn())
-        return getResult(queryFn, prompt)
-      }),
+    reason,
+    reasonWithSystem: ({ system, prompt }) =>
+      reason(prompt, [system, SYSTEM_PROMPT_DYNAMIC_BOUNDARY]),
   }
 }
 
@@ -28,6 +39,7 @@ async function loadDefaultQueryFn(): Promise<QueryFn> {
 async function getResult(
   queryFn: QueryFn,
   prompt: string,
+  systemPrompt?: ClaudeQueryOptions['systemPrompt'],
 ): Promise<{ text: string; meta?: ClaudeCodeMeta }> {
   for await (const message of queryFn({
     prompt,
@@ -39,6 +51,7 @@ async function getResult(
       settings: { autoMemoryEnabled: false },
       settingSources: [],
       persistSession: false,
+      ...(systemPrompt && { systemPrompt }),
     },
   })) {
     if (message.type === 'result' && message.subtype === 'success') {

--- a/src/vendors/github-copilot/agent.test.ts
+++ b/src/vendors/github-copilot/agent.test.ts
@@ -44,6 +44,33 @@ describe('githubCopilot', () => {
     expect(capture.lastSessionConfig?.availableTools).toEqual([])
   })
 
+  it('appends stable instructions without replacing SDK guardrails', async () => {
+    const capture = captureCopilotClient()
+    const client = githubCopilot({ client: capture.client })
+
+    await client.reasonWithSystem?.({
+      system: 'STABLE_TDD_INSTRUCTIONS',
+      prompt: 'DYNAMIC_WRITE_EVIDENCE',
+    })
+
+    expect(capture.lastSessionConfig?.systemMessage).toEqual({
+      mode: 'append',
+      content: 'STABLE_TDD_INSTRUCTIONS',
+    })
+    expect(capture.lastSendAndWaitOptions?.prompt).toBe(
+      'DYNAMIC_WRITE_EVIDENCE',
+    )
+  })
+
+  it('leaves the system message unset for existing direct reason calls', async () => {
+    const capture = captureCopilotClient()
+    const client = githubCopilot({ client: capture.client })
+
+    await client.reason('combined prompt')
+
+    expect(capture.lastSessionConfig?.systemMessage).toBeUndefined()
+  })
+
   it('calls client.start() before creating the session', async () => {
     const capture = captureCopilotClient()
     const client = githubCopilot({ client: capture.client })
@@ -122,6 +149,7 @@ describe('githubCopilot', () => {
 type SessionConfig = {
   availableTools?: string[]
   onPermissionRequest?: PermissionHandler
+  systemMessage?: { mode: 'append'; content: string }
 }
 
 function captureCopilotClient() {

--- a/src/vendors/github-copilot/agent.ts
+++ b/src/vendors/github-copilot/agent.ts
@@ -1,4 +1,7 @@
-import type { PermissionHandler } from '@github/copilot-sdk'
+import type {
+  PermissionHandler,
+  SystemMessageConfig,
+} from '@github/copilot-sdk'
 
 import type { Agent } from '../../types.js'
 import { toVerdict } from '../to-verdict.js'
@@ -6,6 +9,7 @@ import { toVerdict } from '../to-verdict.js'
 type SessionConfig = {
   availableTools?: string[]
   onPermissionRequest?: PermissionHandler
+  systemMessage?: SystemMessageConfig
 }
 
 type CopilotClientLike = {
@@ -30,27 +34,31 @@ export function githubCopilot(
     onPermissionRequest?: PermissionHandler
   } = {},
 ): Agent {
+  const reason = (prompt: string, systemMessage?: SystemMessageConfig) =>
+    toVerdict(async () => {
+      const { client, onPermissionRequest } = await resolveClient(deps)
+      await client.start()
+      const session = await client.createSession({
+        availableTools: [],
+        ...(onPermissionRequest && { onPermissionRequest }),
+        ...(systemMessage && { systemMessage }),
+      })
+      const event = await session.sendAndWait({ prompt })
+      await client.stop()
+      if (!event) {
+        throw new Error(
+          'no response from copilot: sendAndWait returned undefined',
+        )
+      }
+      const meta = buildMeta(event.data.outputTokens)
+      return meta
+        ? { text: event.data.content, meta }
+        : { text: event.data.content }
+    })
   return {
-    reason: (prompt) =>
-      toVerdict(async () => {
-        const { client, onPermissionRequest } = await resolveClient(deps)
-        await client.start()
-        const session = await client.createSession({
-          availableTools: [],
-          ...(onPermissionRequest && { onPermissionRequest }),
-        })
-        const event = await session.sendAndWait({ prompt })
-        await client.stop()
-        if (!event) {
-          throw new Error(
-            'no response from copilot: sendAndWait returned undefined',
-          )
-        }
-        const meta = buildMeta(event.data.outputTokens)
-        return meta
-          ? { text: event.data.content, meta }
-          : { text: event.data.content }
-      }),
+    reason,
+    reasonWithSystem: ({ system, prompt }) =>
+      reason(prompt, { mode: 'append', content: system }),
   }
 }
 


### PR DESCRIPTION
Relates to #46

## What

This is an initial implementation that separates the stable TDD rubric from per-write evidence while keeping `Agent.reason` backward compatible.

Claude receives the stable 6,474-character prefix through the SDK cache boundary. Copilot appends it to the SDK-managed system message. Codex and custom reason-only agents keep the previous combined prompt unchanged.

Would this optional capability shape fit Probity?

## Local verification

`npm run checks` passed with 58 test suites, 546 passing tests, and 26 existing skips.

Across 100 representative writes, 640,926 repeated characters move into the Claude cross-session cache-eligible prefix. The first call still uses the full input. Local tests verify prompt transport and cache eligibility, not an actual provider cache hit or end-to-end latency reduction.