### PR TITLE
fix(enforce-tdd): stop the red step being blocked for not failing first

### DIFF
--- a/src/rules/enforce-tdd.ts
+++ b/src/rules/enforce-tdd.ts
@@ -81,10 +81,12 @@ tests do not count. Restructuring existing tests is not "adding".
   - Adding a test is the red step itself; it is allowed and does not
     require observing it fail first, unless the prior green left a
     refactor unmade (see "Enforcing the refactor phase").
-  - A test added to drive new behavior must be observed failing for
-    the right reason (an assertion, not a syntax or import error) in
-    a prior test run before production code may be written to satisfy
-    it.
+  - Production code that satisfies a new test may not be written until
+    that test has been observed failing for the right reason (an
+    assertion, not a syntax or import error) in a prior test run. This
+    gates the production write, never the write that adds the test: a
+    test cannot fail before it exists, so "no failing run yet" is never
+    a reason to block adding one.
   - A test added to capture existing behavior is allowed to pass
     immediately and must not be blocked for not failing first.
     Examples: characterization tests pinning current implementation,

--- a/test/fixtures/transcripts/tdd-red-after-deletion.jsonl
+++ b/test/fixtures/transcripts/tdd-red-after-deletion.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","message":{"content":[{"type":"text","text":"the banner should label the context as `Context: <name>` instead of printing it bare. follow TDD."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_1","name":"Edit","input":{"file_path":"src/banner.test.ts","old_string":"  it('renders the context bare', () => {\n    expect(renderBanner({ title: 'App', context: 'Development' })).toContain(\n      'Development',\n    )\n  })\n\n","new_string":""}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","content":"The file src/banner.test.ts has been updated successfully."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_2","name":"Bash","input":{"command":"npm test"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_2","content":"Test Files  1 passed (1)\n      Tests  2 passed (2)"}]}}

--- a/test/helpers/banner-fixtures.ts
+++ b/test/helpers/banner-fixtures.ts
@@ -1,0 +1,48 @@
+// Fixtures for the red-after-deletion case. The obsolete test pinning the bare
+// context is already deleted and the suite is green. BANNER_TESTS is the file at
+// that green; BANNER_TESTS_WITH_CONTEXT_LABEL adds the one test that drives the
+// labelled form — a plain red step with no prior failing run to point at.
+
+export const BANNER_TESTS = `import { describe, expect, it } from 'vitest'
+
+import { renderBanner } from './banner.js'
+
+describe('renderBanner', () => {
+  it('renders the title', () => {
+    expect(renderBanner({ title: 'App', context: 'Development' })).toContain(
+      'App',
+    )
+  })
+
+  it('renders the version', () => {
+    expect(
+      renderBanner({ title: 'App', context: 'Development', version: '1.4.0' }),
+    ).toContain('1.4.0')
+  })
+})
+`
+
+export const BANNER_TESTS_WITH_CONTEXT_LABEL = `import { describe, expect, it } from 'vitest'
+
+import { renderBanner } from './banner.js'
+
+describe('renderBanner', () => {
+  it('renders the title', () => {
+    expect(renderBanner({ title: 'App', context: 'Development' })).toContain(
+      'App',
+    )
+  })
+
+  it('renders the version', () => {
+    expect(
+      renderBanner({ title: 'App', context: 'Development', version: '1.4.0' }),
+    ).toContain('1.4.0')
+  })
+
+  it('labels the context', () => {
+    expect(renderBanner({ title: 'App', context: 'Development' })).toContain(
+      'Context: Development',
+    )
+  })
+})
+`

--- a/test/integration/enforce-tdd-claude-code.test.ts
+++ b/test/integration/enforce-tdd-claude-code.test.ts
@@ -31,6 +31,10 @@ import {
   INVOICE_TOTAL_STUBBED_WITH_IMPORT,
 } from '../helpers/invoice-fixtures.js'
 import {
+  BANNER_TESTS,
+  BANNER_TESTS_WITH_CONTEXT_LABEL,
+} from '../helpers/banner-fixtures.js'
+import {
   LEDGER_BORDERLINE_TESTS,
   LEDGER_BORDERLINE_TESTS_WITH_TRANSFER,
 } from '../helpers/ledger-fixtures.js'
@@ -56,6 +60,7 @@ const T = {
     'test/fixtures/transcripts/tdd-noisy-buried-failure.jsonl',
   priorBlock: 'test/fixtures/transcripts/tdd-prior-block-not-in-rules.jsonl',
   removeUsedFn: 'test/fixtures/transcripts/tdd-remove-used-fn.jsonl',
+  redAfterDeletion: 'test/fixtures/transcripts/tdd-red-after-deletion.jsonl',
   refactorSkipped: 'test/fixtures/transcripts/summarize-refactor-skipped.jsonl',
   borderlineRefactor:
     'test/fixtures/transcripts/ledger-borderline-refactor.jsonl',
@@ -126,6 +131,18 @@ describe.concurrent(
         seed: EXISTING_TEST_CONTENT,
         content: PLUS_ONE_TEST,
         transcript: T.cycleCompleted,
+      })
+      expect(result.decision, result.reason).toBe('allow')
+    })
+
+    it('allows a new test after the obsolete one was deleted and the suite went green', async ({
+      runScenario,
+    }) => {
+      const result = await runScenario({
+        filename: 'banner.test.ts',
+        seed: BANNER_TESTS,
+        content: BANNER_TESTS_WITH_CONTEXT_LABEL,
+        transcript: T.redAfterDeletion,
       })
       expect(result.decision, result.reason).toBe('allow')
     })


### PR DESCRIPTION
Fixes #51.

## Problem

The red-phase rule that gates production code reads:

```
  - A test added to drive new behavior must be observed failing for
    the right reason (an assertion, not a syntax or import error) in
    a prior test run before production code may be written to satisfy
    it.
```

The subject is "A test added to drive new behavior". On a diff that only adds a
test, the leading clause matches and the trailing "before production code may be
written" gets lost, so the validator blocks the write that creates the test. That
is impossible to satisfy: the test cannot fail before it exists, and retrying
gives the same block, so the cycle deadlocks.

The trigger is a deletion followed by a green run (an obsolete test removed
before its replacement is written). No failing run is in the window, and no
completed red->green cycle anchors the judgment.

## Change

Rephrase so the subject is the production write, and name the circular case:

```
  - Production code that satisfies a new test may not be written until
    that test has been observed failing for the right reason (an
    assertion, not a syntax or import error) in a prior test run. This
    gates the production write, never the write that adds the test: a
    test cannot fail before it exists, so "no failing run yet" is never
    a reason to block adding one.
```

The gate on production code is unchanged.

## Evidence

Replaying a captured hook payload (same transcript window, same file before and
after), 8 runs per variant:

| variant | denied |
| --- | --- |
| released prompt | 4/8 |
| only this bullet reworded | 0/8 |

## Tests

Adds an integration test pinning the case: an obsolete test is deleted, the suite
runs green, then one new test is added. Fixtures are generic (`renderBanner`).

`npm run checks` passes. The AI suite passes, including the deny cases. Note the
refactor-enforcement deny test is flaky independently of this change — 3/5 on
main and 4/5 with the change in my runs.

Because the misfire is probabilistic and current `main` already allows this
scenario in my sampling, the new test pins the behavior rather than failing
before the change. Happy to reshape it if you'd prefer a different form.
