### PR TITLE
fix(rules): resolve symlinks before matching files-scoped globs

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -84,6 +91,36 @@ export default defineConfig({
     const block = config.rules[0] as { files: readonly string[] }
 
     expect(block.files[0]).not.toContain('\\')
+  })
+
+  it('anchors files globs at the canonical config directory, even when --config reaches it through a symlink', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'probity-config-symlink-'))
+    onTestFinished(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+    const real = path.join(dir, 'real')
+    await mkdir(real, { recursive: true })
+    await writeFile(
+      path.join(real, 'probity.config.ts'),
+      `import { defineConfig, forbidContentPattern } from '@nizos/probity'
+export default defineConfig({
+  rules: [
+    {
+      files: ['src/**'],
+      rules: [forbidContentPattern({ match: /./, reason: 'x' })],
+    },
+  ],
+})
+`,
+    )
+    const alias = path.join(dir, 'alias')
+    await symlink(real, alias)
+    const expectedRoot = await realpath(real)
+
+    const config = await loadConfig(path.join(alias, 'probity.config.ts'))
+    const block = config.rules[0] as { files: readonly string[] }
+
+    expect(block.files[0]).toBe(path.posix.join(expectedRoot, 'src/**'))
   })
 
   it('resolves `@nizos/probity` from a config file that lives outside the package tree', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { createJiti } from 'jiti'
 
 import type { Agent } from './types.js'
 import type { Rule } from './rules/contract.js'
+import { canonicalizePath } from './utils/canonicalize-path.js'
 
 /**
  * A scoped rule block. Groups rules under a shared `files` filter so
@@ -81,7 +82,7 @@ export async function loadConfig(filepath: string): Promise<Config> {
     },
   })
   const module = await jiti.import<{ default: Config }>(filepath)
-  const root = path.dirname(filepath).replace(/\\/g, '/')
+  const root = canonicalizePath(path.dirname(filepath))
   return {
     ...module.default,
     rules: module.default.rules.map((entry) => {

--- a/src/rules/utils/match-paths.test.ts
+++ b/src/rules/utils/match-paths.test.ts
@@ -83,6 +83,71 @@ describe('actionMatchesFilesScope', () => {
     ).toBe(true)
   })
 
+  it('matches a write reported through a symlink against a glob anchored at the resolved path', () => {
+    expect(
+      actionMatchesFilesScope(
+        ['/real/src/**'],
+        { kind: 'write', path: '/link/src/foo.ts', content: '' },
+        (p) => p.replace('/link/', '/real/'),
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a write in scope when the symlink resolves out of the glob', () => {
+    expect(
+      actionMatchesFilesScope(
+        ['/real/src/**'],
+        { kind: 'write', path: '/real/src/linked/foo.ts', content: '' },
+        () => '/elsewhere/foo.ts',
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps a negated subtree excluded for a write reached through a symlink', () => {
+    expect(
+      actionMatchesFilesScope(
+        ['/canon/src/**', '!/canon/src/generated/**'],
+        {
+          kind: 'write',
+          path: '/alias/src/generated/foo.ts',
+          content: '',
+        },
+        (p) => p.replace('/alias/', '/canon/'),
+      ),
+    ).toBe(false)
+  })
+
+  // An in-tree symlink can resolve an explicitly excluded reported path
+  // to an included canonical one; the block still applies. This is the
+  // accepted trade-off: an authoritative reported-path exclusion was
+  // tried and reverted (see git history) because it reopened a far more
+  // common fail-open — a workspace symlink like `node_modules/pkg` that
+  // resolves into `src/**` would silently skip a `!**/node_modules/**`
+  // exclusion meant for real vendor code.
+  it('applies the block when an in-tree symlink resolves an excluded reported path to an included one', () => {
+    expect(
+      actionMatchesFilesScope(
+        ['/repo/src/**', '!/repo/src/excluded/**'],
+        {
+          kind: 'write',
+          path: '/repo/src/excluded/link/foo.ts',
+          content: '',
+        },
+        () => '/repo/src/allowed/foo.ts',
+      ),
+    ).toBe(true)
+  })
+
+  it('applies the block when a workspace symlink resolves an excluded path into the included tree', () => {
+    expect(
+      actionMatchesFilesScope(
+        ['src/**/*.ts', '!**/node_modules/**'],
+        { kind: 'write', path: 'node_modules/pkg/foo.ts', content: '' },
+        () => 'src/foo.ts',
+      ),
+    ).toBe(true)
+  })
+
   it('returns false for a write whose path does not match the glob', () => {
     expect(
       actionMatchesFilesScope(['src/**'], {

--- a/src/rules/utils/match-paths.ts
+++ b/src/rules/utils/match-paths.ts
@@ -1,6 +1,7 @@
 import picomatch from 'picomatch'
 
 import type { Action } from '../../types.js'
+import { canonicalizePath } from '../../utils/canonicalize-path.js'
 
 /**
  * Builds a path matcher from include/exclude patterns. Patterns prefixed
@@ -33,12 +34,23 @@ export function buildMatcher(patterns: string[]): (path: string) => boolean {
  * matches nothing (runtime defense; the type forbids it). Non-write
  * actions pass the block-level filter and self-filter inside their
  * rules. Write actions are matched against `files` via `buildMatcher`.
+ *
+ * A write is tried both as reported and symlink-resolved, since the same
+ * file can arrive under either name. Trying both stops a rule from
+ * skipping the file, and keeps a symlink that points out of the project
+ * in scope — including a workspace symlink (e.g. a linked package under
+ * node_modules) that resolves into an included directory even though
+ * the reported path also matches a vendor-directory exclusion. Fail-open
+ * is the risk this exists to close, so a path is only out of scope when
+ * BOTH spellings agree it's excluded.
  */
 export function actionMatchesFilesScope(
   files: readonly string[],
   action: Action,
+  canonicalize: (p: string) => string = canonicalizePath,
 ): boolean {
   if (files.length === 0) return false
   if (action.kind !== 'write') return true
-  return buildMatcher([...files])(action.path)
+  const matches = buildMatcher([...files])
+  return matches(action.path) || matches(canonicalize(action.path))
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,10 +19,10 @@ export type RuleResult =
  * Adapters translate vendor-specific hook payloads into this shape.
  *
  * - `write` — a file write or edit. `path` is absolute POSIX
- *   (adapters resolve it against the payload `cwd`). The engine
- *   relativizes against the config root at match time, so rule globs
- *   can be authored as `'src/**'` against the project root. Rules that
- *   read the file from disk can pass `path` straight to `fs.open`.
+ *   (adapters resolve it against the payload `cwd`). Block-level `files`
+ *   globs are anchored at the config root, not `path`, so they can be
+ *   authored as `'src/**'` against the project root. Rules that read
+ *   the file from disk can pass `path` straight to `fs.open`.
  * - `command` — a shell command invocation; carries the command text.
  */
 export type Action =

--- a/src/utils/canonicalize-path.test.ts
+++ b/src/utils/canonicalize-path.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, realpath, symlink } from 'node:fs/promises'
+import path from 'node:path'
+
+import { describe, expect, test as baseTest } from 'vitest'
+
+import { makeSandboxDir } from '../../test/helpers/sandbox.js'
+import { canonicalizePath } from './canonicalize-path.js'
+
+const it = baseTest.extend('dir', ({}, { onCleanup }) =>
+  makeSandboxDir(onCleanup),
+)
+
+describe('canonicalizePath', () => {
+  it('resolves a path that reaches an existing file through a symlinked ancestor', async ({
+    dir,
+  }) => {
+    await mkdir(path.join(dir, 'real/src'), { recursive: true })
+    await symlink(path.join(dir, 'real'), path.join(dir, 'link'))
+
+    const canonical = canonicalizePath(path.join(dir, 'link/src'))
+
+    expect(canonical).toBe(await realpath(path.join(dir, 'real/src')))
+  })
+
+  it('resolves the symlinked ancestor of a file that does not exist yet', async ({
+    dir,
+  }) => {
+    await mkdir(path.join(dir, 'real/src'), { recursive: true })
+    await symlink(path.join(dir, 'real'), path.join(dir, 'link'))
+
+    const canonical = canonicalizePath(path.join(dir, 'link/src/new/deep.ts'))
+
+    expect(canonical).toBe(
+      `${await realpath(path.join(dir, 'real/src'))}/new/deep.ts`,
+    )
+  })
+
+  it('returns a forward-slash path, converting any backslashes the resolver returns once the walk reaches the real ancestor', () => {
+    const resolve = (p: string) => {
+      if (p !== '/proj/link/src') throw enoent()
+      return 'C:\\proj\\real\\src'
+    }
+
+    const canonical = canonicalizePath('/proj/link/src/new/deep.ts', resolve)
+
+    expect(canonical).toBe('C:/proj/real/src/new/deep.ts')
+  })
+
+  it('does not produce a double slash when only the filesystem root exists', () => {
+    const resolve = (p: string) => {
+      if (p === '/') return '/'
+      throw enoent()
+    }
+
+    const canonical = canonicalizePath('/nonexistent/sub/foo.ts', resolve)
+
+    expect(canonical).toBe('/nonexistent/sub/foo.ts')
+  })
+
+  it('converts a backslash inside an unresolved tail segment (POSIX path.dirname does not split on it)', () => {
+    const resolve = (p: string) => {
+      if (p !== '/tmp/xxx') throw enoent()
+      return '/tmp/xxx'
+    }
+
+    const canonical = canonicalizePath(
+      '/tmp/xxx/win\\style/src/foo.ts',
+      resolve,
+    )
+
+    expect(canonical).toBe('/tmp/xxx/win/style/src/foo.ts')
+  })
+})
+
+function enoent(): NodeJS.ErrnoException {
+  return Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+}

--- a/src/utils/canonicalize-path.ts
+++ b/src/utils/canonicalize-path.ts
@@ -1,0 +1,28 @@
+import { realpathSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Symlink-resolved form of an absolute path. A write can target a file
+ * that doesn't exist yet, so the longest existing ancestor is resolved
+ * and the rest re-appended. `resolve` is injectable so a Windows-shaped
+ * result (backslashes) can be exercised without a Windows host; it
+ * defaults to the real native realpath.
+ */
+export function canonicalizePath(
+  p: string,
+  resolve: (p: string) => string = realpathSync.native,
+): string {
+  const tail: string[] = []
+  let current = p
+  for (;;) {
+    try {
+      const resolved = resolve(current).replace(/\\/g, '/')
+      return path.posix.join(resolved, ...tail)
+    } catch {
+      const parent = path.dirname(current)
+      if (parent === current) return p
+      tail.unshift(path.basename(current).replace(/\\/g, '/'))
+      current = parent
+    }
+  }
+}

--- a/test/integration/scenarios.e2e.test.ts
+++ b/test/integration/scenarios.e2e.test.ts
@@ -1,5 +1,7 @@
+import { rm, symlink } from 'node:fs/promises'
+
 import type { FileTree } from 'fs-fixture'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, onTestFinished } from 'vitest'
 
 import type { Vendor } from '../../src/cli.js'
 import {
@@ -171,6 +173,29 @@ describe.each([
         expect(result.reason).toContain(CONSOLE_RULE_REASON)
       },
     )
+
+    // Project reached through a symlink (e.g. a firmlink like macOS's
+    // /Users/x/Work -> /Volumes/dev): the config-anchored glob resolves
+    // symlinks, the agent's reported cwd doesn't, so the two must be
+    // compared symlink-aware or the rule silently never matches.
+    it('blocks a forbidden write when the project root is reached through a symlink', async () => {
+      const sandbox = await createSandbox({
+        'probity.config.ts': createProbityConfig(),
+        ...fixtureFiles,
+      })
+      const alias = `${sandbox.path}-alias`
+      await symlink(sandbox.path, alias)
+      onTestFinished(() => rm(alias, { force: true }))
+
+      const result = await runWriteAction({
+        agent,
+        cwd: alias,
+        filePath: 'src/foo.ts',
+      })
+
+      expect(result.decision).toBe('deny')
+      expect(result.reason).toContain(CONSOLE_RULE_REASON)
+    })
   })
 })
 


### PR DESCRIPTION
## Problem

If the project is reached through a symlink — a macOS firmlink like `/Users/x/Work -> /Volumes/dev`, a linked dev environment, `--config` pointed at an aliased path — every `files`-scoped rule block silently stops applying. No error, no trace entry, just an empty response (allow).

## Root cause

Block-level `files` globs get anchored at the config directory (`path.dirname(configFilepath)`, see ADR-0005). Under auto-discovery this happens to already be symlink-resolved, because `process.cwd()` is always canonical on POSIX. `Action.path` (what a rule matches against) is whatever absolute form the agent reported, which isn't resolved. When the project sits behind an alias, the two strings never compare equal, and `actionMatchesFilesScope` returns `false` for every write.

Confirmed on the real binary, same payload, only the path form differs:

```
$ echo '{"file_path":"/Volumes/Development/probity/src/foo.ts", ...}' | node dist/bin.js --agent claude-code
{"...":"deny", "reason":"Probity: ..."}

$ echo '{"file_path":"/Users/x/Work/probity/src/foo.ts", ...}' | node dist/bin.js --agent claude-code
(empty stdout — allow)
```

Same file, same rule, same config. Only the alias makes the difference.

## Fix

- `canonicalizePath` (new) — symlink-resolved form of an absolute path. A `Write` can target a file that doesn't exist yet, so it resolves the longest existing ancestor and re-appends the rest. Normalizes to POSIX either way, since `Action.path`'s contract is POSIX-only (ADR-0004) but the native realpath returns OS-native separators.
- `actionMatchesFilesScope` now matches a write's path against `files` globs using **both** the reported path and its canonicalized form. Union, not canonical-only: a symlink pointing *out* of the project (e.g. a linked package) must stay in scope under its reported name even though canonicalizing it resolves outside every glob.
- `loadConfig` anchors at the canonical config directory too. Auto-discovery already got this for free from `process.cwd()`, but `--config` takes whatever path the caller passed — pointed through an alias, it reopens the exact same bug from the other side.

## A carve-out I tried and reverted

First pass made an exclusion on the *reported* path authoritative, so an in-tree symlink couldn't resolve an explicitly-excluded path back into scope. That closes one narrow case, but it reopens a much more common one: a workspace symlink like `node_modules/pkg -> src` would then silently bypass a `!**/node_modules/**` exclusion, even though the write lands squarely inside `src/**` (this repo's own e2e fixtures use exactly that symlink shape). Reverted — a path is now only out of scope when *both* the reported and canonical spelling agree it's excluded. Left a comment and a regression test at the call site so nobody re-adds it by accident.

## Tests

`npm run checks` clean — 552 tests, lint/format/typecheck all pass.

- `canonicalizePath` — symlinked ancestor (existing + not-yet-created file), Windows-shaped realpath output (backslash normalization, injected resolver since I don't have a Windows box), the `//`-at-root edge case.
- `actionMatchesFilesScope` — matches through a symlink, stays in scope when a symlink resolves *out* of the glob, negation still excludes a subtree reached via symlink, and the `node_modules`-style case above.
- `test/integration/scenarios.e2e.test.ts` — project root reached through a symlink, all four vendors. Confirmed this fails without the fix (reverted, rebuilt, ran it — denies dropped to allows across the board) and passes with it.
- `config.test.ts` — `--config` through a symlink anchors at the realpath, not the alias.

Also fixed a stale doc comment on `Action` (`types.ts`) claiming the engine relativizes paths at match time — it doesn't, the config loader anchors the globs instead, which is the actual mechanism this PR touches.