### PR TITLE
fix(vendors): reconcile a verdict that contradicts its own reasoning

### DIFF
--- a/src/vendors/to-verdict.test.ts
+++ b/src/vendors/to-verdict.test.ts
@@ -78,6 +78,132 @@ describe('toVerdict', () => {
     })
   })
 
+  it('flips a violation to pass when its own reason self-corrects at the end (real captured case: "Correction: pass.")', async () => {
+    const reason =
+      "The failing test asserts canonicalizePath resolves a path reaching an existing file through a symlinked ancestor. A minimal stub could make the symbol exist, but this write implements the full asserted behavior via realpathSync.native. However, the test path 'link/src' fully exists, so realpathSync.native alone satisfies exactly the observed assertion — that is the minimum. This is acceptable green. Correction: pass."
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
+  it('flips a violation to pass when its own reason self-corrects at the end (real captured case: "Correcting: ... a valid red step.")', async () => {
+    const reason =
+      'This write adds one new test that drives new production behavior. A test driving new behavior must be observed failing before it is added-to-drive... however, adding a single new red test is itself the red step and is allowed without observing it fail first. Correcting: this is a single new test, which is a valid red step.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
+  it('keeps a violation whose correction still names a violation', async () => {
+    const reason =
+      'At first I thought this was fine. Correction: this is actually a more serious violation than I first thought.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict).toEqual({ kind: 'violation', reason })
+  })
+
+  it('keeps a violation whose correction negates the pass-affirming word', async () => {
+    const reason = 'Correction: this is not valid as a stub, it goes further.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict).toEqual({ kind: 'violation', reason })
+  })
+
+  it('uses the last correction when an earlier one is itself reversed', async () => {
+    const reason =
+      'Correction: this is valid. Correction: no, on closer look it is still a violation.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict).toEqual({ kind: 'violation', reason })
+  })
+
+  it('keeps a violation with no correction language, unchanged', async () => {
+    const reason = 'No failing test drives this implementation.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict).toEqual({ kind: 'violation', reason })
+  })
+
+  it('never touches a pass verdict, regardless of its reason text', async () => {
+    const reason = 'Correction: actually this should be a violation.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'pass', reason }) }),
+    )
+
+    expect(verdict).toEqual({ kind: 'pass', reason })
+  })
+
+  it('is case-insensitive ("CORRECTING" as well as "Correction")', async () => {
+    const reason = 'CORRECTING: this is allowed after all.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
+  it('recognizes "on second thought ... fine" as a self-correction, not just "correction"', async () => {
+    const reason =
+      'This looks like over-implementation at first glance. Hold on, on second thought this is fine.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
+  it('recognizes "scratch that ... checks out" as a self-correction', async () => {
+    const reason =
+      'This looks like over-implementation at first glance. Hmm, scratch that, it actually checks out.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
+  it('recognizes "take that back — it is correct" as a self-correction', async () => {
+    const reason =
+      'This looks like over-implementation at first glance. No wait, I take that back — it is correct.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
+  it('recognizes "never mind, this holds up" as a self-correction', async () => {
+    const reason =
+      'This looks like over-implementation at first glance. Actually, never mind, this holds up after all.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
+  it('recognizes "walk that back ... no problem" as a self-correction', async () => {
+    const reason =
+      'This looks like over-implementation at first glance. Let me walk that back; there is no problem here.'
+    const verdict = await toVerdict(() =>
+      Promise.resolve({ text: JSON.stringify({ kind: 'violation', reason }) }),
+    )
+
+    expect(verdict.kind).toBe('pass')
+  })
+
   it('forwards AgentMeta from the response source onto the parsed verdict', async () => {
     const verdict = await toVerdict(() =>
       Promise.resolve({

--- a/src/vendors/to-verdict.ts
+++ b/src/vendors/to-verdict.ts
@@ -49,7 +49,50 @@ function parseVerdict(text: string): Verdict {
       reason: `validator returned unexpected shape at ${where}: ${what}`,
     }
   }
-  return result.data
+  return reconcileSelfContradiction(result.data)
+}
+
+const CORRECTION_MARKER_RE =
+  /\bcorrect(ion|ing)\b|\bon second thought\b|\bscratch that\b|\btake (that|it) back\b|\bnever\s?mind\b|\bwalk (that|it) back\b/gi
+const AFFIRMS_PASS_RE =
+  /\b(pass(es)?|valid|allow(ed)?|fine|checks out|correct|holds up|no problem)\b/i
+const NEGATION_RE = /\b(not|n't|never|isn't|doesn't|wasn't|weren't)\b/i
+const NEGATION_WINDOW = 20
+
+/**
+ * A violation whose own reason ends with a correction that affirms
+ * pass is flipped to pass. The validator's response schema puts "kind"
+ * before "reason" with thinking disabled, so "reason" is the only
+ * place reasoning happens — but by the time it self-corrects there,
+ * "kind" is already committed. Reordering the schema to fix this at
+ * the source (reason before kind) was tried and measured: it more
+ * than tripled the error rate on an unrelated real judgment call
+ * (13% -> 57% over 30 trials each), so this reconciles after the
+ * fact instead, without touching how the model reasons at all.
+ */
+function reconcileSelfContradiction(verdict: Verdict): Verdict {
+  if (verdict.kind !== 'violation') return verdict
+  const marker = lastCorrectionMarker(verdict.reason)
+  if (!marker) return verdict
+  const tail = verdict.reason.slice(marker.index)
+  if (/violat/i.test(tail)) return verdict
+  const affirms = AFFIRMS_PASS_RE.exec(tail)
+  if (!affirms) return verdict
+  // The marker phrase itself starts the tail, so the negation lookback
+  // must not reach back into it (e.g. "never mind" as a marker would
+  // otherwise trip NEGATION_RE's own "never").
+  const searchStart = marker[0].length
+  const before = tail.slice(
+    Math.max(searchStart, affirms.index - NEGATION_WINDOW),
+    affirms.index,
+  )
+  if (NEGATION_RE.test(before)) return verdict
+  return { ...verdict, kind: 'pass' }
+}
+
+function lastCorrectionMarker(reason: string): RegExpMatchArray | undefined {
+  const markers = [...reason.matchAll(CORRECTION_MARKER_RE)]
+  return markers.at(-1)
 }
 
 /**


### PR DESCRIPTION
Fixes #55.

## Problem

`enforceTdd`'s validator call runs with `thinking: { type: 'disabled' }` and a response schema that puts `kind` before `reason`. It's a plain-text completion, not tool-calling, so generation is strictly left-to-right — the model commits to `kind` before it's written a word of `reason`, because `reason` is the only place reasoning happens at all. On a borderline case it sometimes self-corrects mid-explanation, but by then `kind` is already locked in.

Two real captures (see #55 for the full write-up):

> "...This is acceptable green. **Correction: pass.**" — returned as `violation`.

> "...Correcting: this is a single new test, which is a **valid red step**." — returned as `violation`.

## A fix I tried and reverted

Reordering the schema to `{"reason":...,"kind":...}` seemed like the obvious fix. Measured it against a real scenario already in the test suite, 30 trials each side:

| Schema | Correct |
| --- | --- |
| original (`kind` first) | 26/30 (87%) |
| reordered (`reason` first) | 13/30 (43%) |

More than triples the error rate on an unrelated judgment call — asking the model to justify itself with nothing committed yet seems to invite rationalization toward leniency. Not shipping that; details in #55.

## Fix

`reconcileSelfContradiction` in `to-verdict.ts`, applied after schema validation. Never touches how the model reasons — just catches the contradiction after the fact. A `violation` whose `reason` ends with a correction marker ("Correction:", "Correcting:", "on second thought", "scratch that", "take that back", "never mind", "walk that back") that affirms pass gets flipped to `pass`, unless:

- the correction still names a violation ("...actually a more serious violation"),
- the affirming word is itself negated ("not valid"), or
- a later correction in the same reason reverses an earlier one (uses the *last* marker).

Only flips toward `pass`, never the reverse — a wrongly-kept violation costs a retry, a wrongly-flipped pass would be a silent fail-open.

Deliberately not exhaustive: asked the model live for realistic self-correction phrasings that avoid the word "correction," got 8, caught 5 with the extended marker list (plus both real captures = 7 total). The 3 misses are principled: one has no stated conclusion on its own, one is a double-negative unsafe to parse with a simple regex, and one places the affirmation *before* the marker instead of after (checking backward risks false-flipping an ordinary violation that discusses a hypothetical "fine" case before explaining why it's actually blocked).

## Tests

`npm run checks` clean — 550 tests, lint/format/typecheck pass.

- Both real captures pinned verbatim.
- Correction that still names a violation → stays `violation`.
- Negated affirming word → stays `violation`.
- Multiple corrections, later one reverses the earlier → uses the last, stays `violation`.
- No correction language → unchanged.
- `pass` verdicts never touched, regardless of reason text.
- Case-insensitive ("CORRECTING" as well as "Correction").
- Five additional real-world phrasings ("on second thought," "scratch that," "take that back," "never mind," "walk that back") gathered live and added one at a time via TDD — found and fixed a real bug along the way (the negation guard's word list included "never," which collided with the "never mind" marker itself).