### PR TITLE
fix(github-copilot): accept object toolArgs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -103,6 +103,13 @@ Note the use of `bash` and `powershell` in this example, select the shell option
 
 Every tool call fires the hook; probity's rules pass through non-write actions. Probity accepts Copilot's `bash`, `create`, and `edit` tool payloads.
 
+Current camelCase Copilot payloads send `toolArgs` as an object. Probity
+accepts that object form and the legacy JSON-string form for `bash`,
+`create`, and `edit`; malformed payloads for those known tools fail closed,
+while unknown tools pass through. This compatibility applies to the
+camelCase payload fields (`sessionId`, `toolName`, and `toolArgs`) used by
+current Copilot CLI hooks.
+
 Further reading: [GitHub Copilot's hooks reference](https://docs.github.com/en/copilot/reference/hooks-configuration).
 
 ## CLI

--- a/src/vendors/github-copilot/adapter.test.ts
+++ b/src/vendors/github-copilot/adapter.test.ts
@@ -14,7 +14,7 @@ import { parseAction, sessionPath, toResponse } from './adapter.js'
 type Payload = {
   cwd?: string
   toolName: string
-  toolArgs: string
+  toolArgs: unknown
 }
 
 const it = baseTest
@@ -56,9 +56,25 @@ describe('github-copilot adapter', () => {
 
   it('extracts the command text from a bash payload', async () => {
     const { action, payload } = await setup('pre-bash-npm-test.json')
-    const toolArgs = parseAs<{ command: string }>(payload.toolArgs)
+    const toolArgs = parseLegacyArgs<{ command: string }>(payload.toolArgs)
 
     expect(action).toMatchObject({ command: toolArgs.command })
+  })
+
+  it('accepts current object-valued bash toolArgs with an extra description', async () => {
+    const result = await parseAction({
+      cwd: '/workspaces/probity',
+      toolName: 'bash',
+      toolArgs: {
+        command: 'npm test',
+        description: 'Run the test suite',
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      actions: [{ kind: 'command', command: 'npm test' }],
+    })
   })
 
   it('builds a deny response with permissionDecision and reason', () => {
@@ -76,10 +92,10 @@ describe('github-copilot adapter', () => {
     expect(toResponse({ kind: 'allow' })).toBe('')
   })
 
-  it('rejects a payload whose toolArgs is not a JSON-encoded string', async () => {
+  it('rejects malformed known-tool payloads', async () => {
     const result = await parseAction({
       toolName: 'bash',
-      toolArgs: 'not-valid-json',
+      toolArgs: { description: 'missing command' },
     })
 
     expect(result.ok).toBe(false)
@@ -93,11 +109,35 @@ describe('github-copilot adapter', () => {
 
   it('maps create payload path (absolute POSIX) + file_text onto the write action', async () => {
     const { action, payload } = await setup('pre-create-new-test.json')
-    const args = parseAs<{ path: string; file_text: string }>(payload.toolArgs)
+    const args = parseLegacyArgs<{ path: string; file_text: string }>(
+      payload.toolArgs,
+    )
 
     expect(action).toMatchObject({
       path: '/workspaces/probity/test/calculator.test.ts',
       content: args.file_text,
+    })
+  })
+
+  it('accepts current object-valued create toolArgs', async () => {
+    const result = await parseAction({
+      cwd: '/workspaces/probity',
+      toolName: 'create',
+      toolArgs: {
+        path: 'test/calculator.test.ts',
+        file_text: 'x',
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      actions: [
+        {
+          kind: 'write',
+          path: '/workspaces/probity/test/calculator.test.ts',
+          content: 'x',
+        },
+      ],
     })
   })
 
@@ -114,6 +154,31 @@ describe('github-copilot adapter', () => {
         old_str: 'MARKER',
         new_str: 'REPLACED',
       }),
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      actions: [
+        {
+          kind: 'write',
+          path: filePath,
+          content: 'before\nREPLACED\nafter\n',
+        },
+      ],
+    })
+  })
+
+  it('accepts current object-valued edit toolArgs', async ({ makeFile }) => {
+    const filePath = await makeFile('before\nMARKER\nafter\n')
+
+    const result = await parseAction({
+      cwd: '/workspaces/probity',
+      toolName: 'edit',
+      toolArgs: {
+        path: filePath,
+        old_str: 'MARKER',
+        new_str: 'REPLACED',
+      },
     })
 
     expect(result).toEqual({
@@ -261,4 +326,11 @@ function ok(result: ParseActionResult): Action {
     throw new Error(`expected exactly one action, got ${result.actions.length}`)
   }
   return result.actions[0]!
+}
+
+function parseLegacyArgs<T>(toolArgs: unknown): T {
+  if (typeof toolArgs !== 'string') {
+    throw new Error('expected legacy JSON-string toolArgs')
+  }
+  return parseAs<T>(toolArgs)
 }

--- a/src/vendors/github-copilot/adapter.ts
+++ b/src/vendors/github-copilot/adapter.ts
@@ -20,26 +20,37 @@ export type ResponseShape = {
 
 const bashSchema = z.object({
   toolName: z.literal('bash'),
-  toolArgs: JsonString.pipe(z.object({ command: z.string() })),
+  toolArgs: z.union([
+    z.object({ command: z.string() }),
+    JsonString.pipe(z.object({ command: z.string() })),
+  ]),
 })
 
 const createSchema = z.object({
   toolName: z.literal('create'),
-  toolArgs: JsonString.pipe(
+  toolArgs: z.union([
     z.object({ path: z.string(), file_text: z.string() }),
-  ),
+    JsonString.pipe(z.object({ path: z.string(), file_text: z.string() })),
+  ]),
   cwd: z.string().min(1),
 })
 
 const editSchema = z.object({
   toolName: z.literal('edit'),
-  toolArgs: JsonString.pipe(
+  toolArgs: z.union([
     z.object({
       path: z.string(),
       old_str: z.string(),
       new_str: z.string(),
     }),
-  ),
+    JsonString.pipe(
+      z.object({
+        path: z.string(),
+        old_str: z.string(),
+        new_str: z.string(),
+      }),
+    ),
+  ]),
   cwd: z.string().min(1),
 })
 
@@ -47,9 +58,8 @@ const editSchema = z.object({
  * The validated payload shape for a `create` tool call. Intersect with
  * the ceremony fields Copilot sends (sessionId, timestamp) when
  * stamping out test payloads so the validated portion tracks the
- * adapter automatically. `toolArgs` arrives as a JSON string on the
- * wire (parsed by `JsonString.pipe`), so the input shape carries the
- * unparsed string form.
+ * adapter automatically. `toolArgs` accepts both the current object form
+ * and the legacy JSON-string form.
  */
 export type WriteInput = z.input<typeof createSchema>
 

--- a/test/fixtures/github-copilot/pre-bash-npm-test-object.json
+++ b/test/fixtures/github-copilot/pre-bash-npm-test-object.json
@@ -1,0 +1,10 @@
+{
+  "sessionId": "56c13b41-a711-40e3-a16d-e911c1340791",
+  "timestamp": 1777047490575,
+  "cwd": "/workspaces/probity",
+  "toolName": "bash",
+  "toolArgs": {
+    "command": "npm test",
+    "description": "Run tests with npm test"
+  }
+}

--- a/test/integration/cli.e2e.test.ts
+++ b/test/integration/cli.e2e.test.ts
@@ -31,6 +31,17 @@ describe('probity cli (integration)', () => {
     expect(decodeResponse('claude-code', getRawStdout()).decision).toBe('allow')
   })
 
+  it('accepts current GitHub Copilot camelCase payloads with object toolArgs and extra descriptions', async () => {
+    const { getRawStdout } = await setup({
+      payloadFixture:
+        'test/fixtures/github-copilot/pre-bash-npm-test-object.json',
+      config: CONFIG_FIXTURE,
+      vendor: 'github-copilot',
+    })
+
+    expect(getRawStdout()).toBe('')
+  })
+
   it('loads the config from --config <path> instead of discovering one', async () => {
     const { getRawStdout } = await setup({
       payloadFixture: 'test/fixtures/claude-code/write-kebab-case.json',


### PR DESCRIPTION
## Summary

- accept current object-valued toolArgs for bash, create, and edit
- preserve legacy JSON-string payloads, fail-closed known-tool validation, and unknown-tool passthrough
- add adapter and CLI fixture coverage plus setup compatibility notes

Fixes #68

## Validation

- focused adapter and CLI tests: 30 passed
- related Copilot tests: 48 passed
- targeted ESLint, Prettier, and typecheck passed