### PR TITLE
docs: update Codex hooks setup

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -49,14 +49,7 @@ Further reading: [Claude Code's hooks documentation](https://code.claude.com/doc
 
 ## OpenAI Codex
 
-Codex hooks are gated behind a feature flag. Enable it in `~/.codex/config.toml`:
-
-```toml
-[features]
-codex_hooks = true
-```
-
-Then add a `PreToolUse` hook in `~/.codex/hooks.json`:
+Codex hooks are enabled by default. Add a `PreToolUse` hook in `~/.codex/hooks.json`:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- remove the obsolete `codex_hooks = true` feature-flag setup step
- clarify that Codex hooks are enabled by default

## Verification

- `npm run checks`

Resolves the outdated setup guidance identified in the OpenAI Codex section of `docs/setup.md`.