### PR TITLE
Codex: Update Codex SDK to 0.153.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.3.204",
         "@ast-grep/napi": "^0.42.1",
         "@github/copilot-sdk": "1.0.5",
-        "@openai/codex-sdk": "0.143.0",
+        "@openai/codex-sdk": "0.153.0",
         "jiti": "^2.6.1",
         "picomatch": "^4.0.4",
         "zod": "^4.3.6"
@@ -1271,10 +1271,11 @@
         }
       }
     },
-    "node_modules/@openai/codex": {
+    "node_modules/@nizos/probity/node_modules/@openai/codex": {
       "version": "0.143.0",
       "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0.tgz",
       "integrity": "sha512-6h53sNtESIYncWVwU7zEjdVajwcad/0H94MOrgGqhwBMa9RRUDVG6DU9E9euC7yRdtrsKDAkJkz/m5moZ6MU3A==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -1291,11 +1292,152 @@
         "@openai/codex-win32-x64": "npm:@openai/codex@0.143.0-win32-x64"
       }
     },
-    "node_modules/@openai/codex-darwin-arm64": {
+    "node_modules/@nizos/probity/node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
       "version": "0.143.0-darwin-arm64",
       "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-darwin-arm64.tgz",
       "integrity": "sha512-hs9bPkE1c0+EtbHxxVfhaaGl1u6/LVdhEtOX5t9N+ri54yjMUkzKJLc7MOBa1DYRMDTWT+lPEfeB+8Fv9coTKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nizos/probity/node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.143.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-darwin-x64.tgz",
+      "integrity": "sha512-xHbrb/Qkj+ZZqYkAuio3mcFxpqlg/NNpBDz5iMKlGa7XfK3miUu6R50c9cRW1ZPQVRfRnFhs4l7OhI5u5r+HvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nizos/probity/node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.143.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-linux-arm64.tgz",
+      "integrity": "sha512-1TMx1a/YBEY0SBhPGn8z9HjOpaDssw+WJiIi/+r0CB5uZf6qnALN02TrZTZl2PSUI8olnBf/VccjnwVCrzR38w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nizos/probity/node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.143.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-linux-x64.tgz",
+      "integrity": "sha512-B6v6oUgBbjt1bL7yBbRp7e0vLiVOjRdz9Wykotve52Aq2H2TeiCqxM5BSOaFkmNO6VxE0seW7hTi2UZF9x8LLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nizos/probity/node_modules/@openai/codex-sdk": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.143.0.tgz",
+      "integrity": "sha512-AQb06ERd2Z6MGgyiL3pcN4sw7m4ESkVSy1nSd2ks+cmchnk06AMOy8lRCH5dkyxI+dtnqWa7dLolqf7aRuOqJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai/codex": "0.143.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nizos/probity/node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.143.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-win32-arm64.tgz",
+      "integrity": "sha512-8ntYPI3IQWZuayL214tYanuYhom23RxHUWRkmay45hGymEW4TwwFqzppKXEzcBXrCF5uSWlOMMG+B2elN6kWuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nizos/probity/node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.143.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-win32-x64.tgz",
+      "integrity": "sha512-d60HLkzSQ7rdL35xPxH1x3g8DuJjEbhEx1UOK5ivA1PBD9eWvP46rtdHkSvCZyqHUhaHFr5We2SugE9+Y8HhVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.153.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.0.tgz",
+      "integrity": "sha512-k55kUZaclNi5ceUStSVuyW834ruA6AEdzTK7Xi3M1mOyXokUmq1sJLXm1RJ3XD2S7bRPeF1EXNsYB5Qxwus0mw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.153.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.153.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.153.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.0-darwin-arm64.tgz",
+      "integrity": "sha512-C9F3HVEYekVJC3WhiGSztcxItWBwd7Y6hTWoDqa9Z9aLWsYywzqChABB59n7G5F5jCil9wxW3+u2L6uiVUydmw==",
       "cpu": [
         "arm64"
       ],
@@ -1310,9 +1452,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.143.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-darwin-x64.tgz",
-      "integrity": "sha512-xHbrb/Qkj+ZZqYkAuio3mcFxpqlg/NNpBDz5iMKlGa7XfK3miUu6R50c9cRW1ZPQVRfRnFhs4l7OhI5u5r+HvA==",
+      "version": "0.153.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.0-darwin-x64.tgz",
+      "integrity": "sha512-DO5u+X/eL8pObrV0WDErOjS9DeuDvVuOL5oHR5y5Yklp0NGoGj3oOHsmaSXjGesiIiu3IX8l4pzS6dbeQXJAvQ==",
       "cpu": [
         "x64"
       ],
@@ -1327,9 +1469,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.143.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-linux-arm64.tgz",
-      "integrity": "sha512-1TMx1a/YBEY0SBhPGn8z9HjOpaDssw+WJiIi/+r0CB5uZf6qnALN02TrZTZl2PSUI8olnBf/VccjnwVCrzR38w==",
+      "version": "0.153.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.0-linux-arm64.tgz",
+      "integrity": "sha512-N2zLgmuslhMoC2RFC2aDkcCWk3iapZmBlSiESpjXFF+UMNxIpNxWJ5qQtQrCp5Md7kYbF4/EFy8RqJ8tL8UTeA==",
       "cpu": [
         "arm64"
       ],
@@ -1344,9 +1486,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.143.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-linux-x64.tgz",
-      "integrity": "sha512-B6v6oUgBbjt1bL7yBbRp7e0vLiVOjRdz9Wykotve52Aq2H2TeiCqxM5BSOaFkmNO6VxE0seW7hTi2UZF9x8LLA==",
+      "version": "0.153.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.0-linux-x64.tgz",
+      "integrity": "sha512-sFF+g7p1o6sZVL6PHd9JTYrP2j3xao3Qeu5AngcrD5brWrCc+w9ifBJCJuRSM728WfgjXML9PQPdHPaZSeHAEA==",
       "cpu": [
         "x64"
       ],
@@ -1360,12 +1502,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.143.0.tgz",
-      "integrity": "sha512-AQb06ERd2Z6MGgyiL3pcN4sw7m4ESkVSy1nSd2ks+cmchnk06AMOy8lRCH5dkyxI+dtnqWa7dLolqf7aRuOqJA==",
+      "version": "0.153.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.153.0.tgz",
+      "integrity": "sha512-60D0LTPVczybWn4Db4Hk8uMRkBYex45MKax1PLrF/sqFRe/5oaZ+QykyGT9VCPnIbontMf5x7F7EqpEjRa6wug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.143.0"
+        "@openai/codex": "0.153.0"
       },
       "engines": {
         "node": ">=18"
@@ -1373,9 +1515,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.143.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-win32-arm64.tgz",
-      "integrity": "sha512-8ntYPI3IQWZuayL214tYanuYhom23RxHUWRkmay45hGymEW4TwwFqzppKXEzcBXrCF5uSWlOMMG+B2elN6kWuQ==",
+      "version": "0.153.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.0-win32-arm64.tgz",
+      "integrity": "sha512-Ro+/2oAQnOObxuw3hpr+anv+j9hFmql/2iDxd7v0m46ctZy8x6ygW/Ud4f9CB1UXlRRsDhW+Tu9UAd5X9vTL1g==",
       "cpu": [
         "arm64"
       ],
@@ -1390,9 +1532,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.143.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-win32-x64.tgz",
-      "integrity": "sha512-d60HLkzSQ7rdL35xPxH1x3g8DuJjEbhEx1UOK5ivA1PBD9eWvP46rtdHkSvCZyqHUhaHFr5We2SugE9+Y8HhVA==",
+      "version": "0.153.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.0-win32-x64.tgz",
+      "integrity": "sha512-eXvmitT1Hmr6d8n9r5HVjTuSgdHtxFSyXh0c3rRnaTcJA0ef8JnI5LY0TJci/QHYLNJGaEMBZ5R4dEdB2d87Lw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.204",
     "@ast-grep/napi": "^0.42.1",
     "@github/copilot-sdk": "1.0.5",
-    "@openai/codex-sdk": "0.143.0",
+    "@openai/codex-sdk": "0.153.0",
     "jiti": "^2.6.1",
     "picomatch": "^4.0.4",
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary

- update `@openai/codex-sdk` from `0.143.0` to `0.153.0`
- regenerate the lockfile for the SDK’s pinned Codex CLI and platform-specific binaries
- keep the SDK exactly pinned so installs use the release Probity was built and tested against

No source changes were required; the existing Codex thread options and response handling remain type-compatible with `0.153.0`.

The lockfile retains `0.143.0` only beneath the dogfood `@nizos/probity@1.10.0` dev dependency, which still declares that exact version.

## Verification

- `npm run checks`
- 58 test files passed
- 537 tests passed, 26 skipped